### PR TITLE
Fix artefact build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,5 +20,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: AMS2CM
-          path: bin/Debug/net6.0-windows/publish/**
+          path: |
+            src/CLI/bin/Debug/net6.0-windows/publish/**
+            LICENSE
           if-no-files-found: error


### PR DESCRIPTION
https://github.com/OpenSimTools/AMS2CM/actions/runs/4718694644
```
No files were found with the provided path: bin/Debug/net6.0-windows/publish/**. No artifacts will be uploaded.
```

Also adds LICENSE file to the artefact.