### PR TITLE
Generate Bootfiles from game unless provided

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,13 +9,17 @@ on:
 jobs:
   build:
     runs-on: windows-latest
+    permissions:
+      packages: read
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-dotnet@v2
         with:
           dotnet-version: '6.0.x'
       - if: ${{ github.ref == 'refs/heads/main' }}
-        run: dotnet publish
+        run: |
+          dotnet nuget add source --username USERNAME --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/OpenSimTools/index.json"
+          dotnet publish
       - if: ${{ github.ref == 'refs/heads/main' }}
         uses: actions/upload-artifact@v3
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-﻿.idea/
+﻿.vs/
+.idea/
 bin/
 obj/
-/*.user
+*.user

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -13,6 +13,7 @@
     <ItemGroup>
         <PackageReference Include="Gameloop.Vdf" Version="0.6.2" />
         <PackageReference Include="Gameloop.Vdf.JsonConverter" Version="0.2.1" />
+        <PackageReference Include="PCarsTools" Version="1.1.2.2" />
         <PackageReference Include="SevenZipExtractor" Version="1.0.17" />
     </ItemGroup>
 </Project>

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -13,7 +13,7 @@
     <ItemGroup>
         <PackageReference Include="Gameloop.Vdf" Version="0.6.2" />
         <PackageReference Include="Gameloop.Vdf.JsonConverter" Version="0.2.1" />
-        <PackageReference Include="PCarsTools" Version="1.1.2.2" />
+        <PackageReference Include="PCarsTools" Version="1.1.2.3" />
         <PackageReference Include="SevenZipExtractor" Version="1.0.17" />
     </ItemGroup>
 </Project>

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -13,7 +13,7 @@
     <ItemGroup>
         <PackageReference Include="Gameloop.Vdf" Version="0.6.2" />
         <PackageReference Include="Gameloop.Vdf.JsonConverter" Version="0.2.1" />
-        <PackageReference Include="PCarsTools" Version="1.1.2.3" />
+        <PackageReference Include="PCarsTools" Version="1.1.2.4" />
         <PackageReference Include="SevenZipExtractor" Version="1.0.17" />
     </ItemGroup>
 </Project>

--- a/src/Core/ModManager.cs
+++ b/src/Core/ModManager.cs
@@ -162,6 +162,10 @@ public class ModManager
                     Console.WriteLine("- Appending driveline records");
                     PostProcessor.AppendDrivelineRecords(_installPaths.GamePath, modConfigs.SelectMany(_ => _.DrivelineRecords));
                 }
+                else
+                {
+                    Console.WriteLine("Post-processing not required");
+                }
             }
         }
         finally

--- a/src/Core/Mods/ExtractedMod.cs
+++ b/src/Core/Mods/ExtractedMod.cs
@@ -1,0 +1,92 @@
+﻿namespace Core.Mods;
+
+public abstract class ExtractedMod : IMod
+{
+    private static readonly string[] DirsAtRootLowerCase =
+    {
+        "cameras",
+        "characters",
+        "effects",
+        "gui",
+        "pakfiles",
+        "render",
+        "text",
+        "tracks",
+        "upgrade",
+        "vehicles"
+    };
+
+    protected static readonly IMod.ConfigEntries EmptyConfig =
+        new(Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>());
+
+    protected readonly string _extractedPath;
+    protected readonly List<string> _installedFiles = new();
+
+    public ExtractedMod(string packageName, string extractedPath)
+    {
+        PackageName = packageName;
+        Config = EmptyConfig;
+        _extractedPath = extractedPath;
+    }
+
+    public string PackageName
+    {
+        get;
+    }
+
+    public IMod.InstalledState Installed
+    {
+        get;
+        private set;
+    }
+
+    public IMod.ConfigEntries Config
+    {
+        get;
+        private set;
+    }
+
+    public IReadOnlyCollection<string> InstalledFiles => _installedFiles;
+
+    public void Install(string dstPath)
+    {
+        if (Installed != IMod.InstalledState.NotInstalled)
+        {
+            throw new InvalidOperationException();
+        }
+        Installed = IMod.InstalledState.PartiallyInstalled;
+
+        foreach (var rootPath in FindModRootDirs())
+        {
+            JsgmeFileInstaller.InstallFiles(rootPath, dstPath,
+                relativeFilePath => _installedFiles.Add(relativeFilePath));
+        }
+
+        Config = GenerateConfig();
+
+        Installed = IMod.InstalledState.Installed;
+    }
+
+    private IEnumerable<string> FindModRootDirs()
+    {
+        return FindRootContaining(_extractedPath, DirsAtRootLowerCase);
+    }
+
+    private static List<string> FindRootContaining(string path, string[] contained)
+    {
+        var roots = new List<string>();
+        foreach (var subdir in Directory.GetDirectories(path))
+        {
+            var localName = Path.GetFileName(subdir).ToLowerInvariant();
+            if (contained.Contains(localName))
+            {
+                return new List<string> { path };
+            }
+            roots.AddRange(FindRootContaining(subdir, contained));
+        }
+
+        return roots;
+    }
+
+    protected abstract IMod.ConfigEntries GenerateConfig();
+}

--- a/src/Core/Mods/GeneratedBootfiles.cs
+++ b/src/Core/Mods/GeneratedBootfiles.cs
@@ -1,0 +1,98 @@
+﻿using PCarsTools;
+using PCarsTools.Encryption;
+
+namespace Core.Mods;
+
+public class GeneratedBootfiles : ExtractedMod
+{
+    private const string VirtualPackageName = "__bootfiles_generated";
+    private const string PakfilesDirectory = "Pakfiles";
+    private const string BootFlowPakFileName = "BOOTFLOW.bff";
+    private const string PhysicsPersistentPakFileName = "PHYSICSPERSISTENT.bff";
+
+    private readonly string _pakPath;
+    private readonly string BmtFilesWildcard =
+        Path.Combine("vehicles", "_data", "effects", "backfire", "*.bmt");
+
+    public GeneratedBootfiles(string gamePath, string generationBasePath)
+        : base(VirtualPackageName, Path.Combine(generationBasePath, VirtualPackageName))
+    {
+        _pakPath = Path.Combine(gamePath, PakfilesDirectory);
+        GenerateBootfiles();
+    }
+
+    private void GenerateBootfiles()
+    {
+        ExtractPakFileFromGame(BootFlowPakFileName);
+        ExtractPakFileFromGame(PhysicsPersistentPakFileName);
+        CreateEmptyPakFile("BOOTSPLASH", ExtractedPakPath(BootFlowPakFileName));
+        CreateEmptyFile(ExtractedPakPath($"{PhysicsPersistentPakFileName}{JsgmeFileInstaller.RemoveFileSuffix}"));
+        DeleteExtractedFiles(BmtFilesWildcard); // Is it really necessary?
+    }
+
+    private void DeleteExtractedFiles(string wildcardRelative)
+    {
+        var wildcardAbsolute = Path.Combine(_extractedPath, wildcardRelative);
+        foreach(var file in Directory.EnumerateFiles(wildcardAbsolute))
+        {
+            File.Delete(file);
+        }
+    }
+
+    private void ExtractPakFileFromGame(string fileName)
+    {
+        BPakFileEncryption.SetKeyset(KeysetType.PC2AndAbove);
+        var filePath = Path.Combine(_pakPath, fileName);
+        BPakFile.FromFile(filePath, withExtraInfo: true).UnpackAll(_extractedPath);
+    }
+
+    private string ExtractedPakPath(string name) =>
+        Path.Combine(_extractedPath, PakfilesDirectory, name);
+
+    private const string fileTag = " KAP";
+    private const uint version = 1 << 11 | 1;
+    private const uint fileCount = 0;
+
+    private const uint tocEntrySize = 16; // Required or PCarsTools will fail
+    private const uint crc = 0;
+    private const uint extInfoSize = 0x308; // Required for cert size even with no encryption
+
+    private const byte flags = 0;
+    private const byte encryptionType = 0;
+
+    private void CreateEmptyPakFile(string name, string path)
+    {
+        CreateParentDirectory(path);
+        using var writer = new BinaryWriter(File.Create(path));
+        writer.Write(fileTag.ToCharArray());
+        writer.Write(version);
+        writer.Write(fileCount);
+        writer.Write(new byte[12]);
+        writer.Write(name.ToCharArray());
+        writer.Write(new byte[0x100 - name.Length]);
+        writer.Write(tocEntrySize);
+        writer.Write(crc);
+        writer.Write(extInfoSize);
+        writer.Write(new byte[8]);
+        writer.Write(flags);
+        writer.Write(encryptionType);
+        writer.Write(new byte[2]);
+        writer.Write(new byte[tocEntrySize]);
+        writer.Write(new byte[extInfoSize]);
+    }
+
+    private void CreateEmptyFile(string path)
+    {
+        CreateParentDirectory(path);
+        File.Create(path).Close();
+    }
+
+    private void CreateParentDirectory(string path)
+    {
+        var parent = Path.GetDirectoryName(path);
+        if (parent is not null)
+            Directory.CreateDirectory(parent);
+    }
+
+    protected override IMod.ConfigEntries GenerateConfig() => EmptyConfig;
+}

--- a/src/Core/Mods/GeneratedBootfiles.cs
+++ b/src/Core/Mods/GeneratedBootfiles.cs
@@ -11,8 +11,6 @@ public class GeneratedBootfiles : ExtractedMod
     private const string PhysicsPersistentPakFileName = "PHYSICSPERSISTENT.bff";
 
     private readonly string _pakPath;
-    private readonly string BmtFilesWildcard =
-        Path.Combine("vehicles", "_data", "effects", "backfire", "*.bmt");
 
     public GeneratedBootfiles(string gamePath, string generationBasePath)
         : base(VirtualPackageName, Path.Combine(generationBasePath, VirtualPackageName))
@@ -27,23 +25,14 @@ public class GeneratedBootfiles : ExtractedMod
         ExtractPakFileFromGame(PhysicsPersistentPakFileName);
         CreateEmptyPakFile("BOOTSPLASH", ExtractedPakPath(BootFlowPakFileName));
         CreateEmptyFile(ExtractedPakPath($"{PhysicsPersistentPakFileName}{JsgmeFileInstaller.RemoveFileSuffix}"));
-        DeleteExtractedFiles(BmtFilesWildcard); // Is it really necessary?
-    }
-
-    private void DeleteExtractedFiles(string wildcardRelative)
-    {
-        var wildcardAbsolute = Path.Combine(_extractedPath, wildcardRelative);
-        foreach(var file in Directory.EnumerateFiles(wildcardAbsolute))
-        {
-            File.Delete(file);
-        }
     }
 
     private void ExtractPakFileFromGame(string fileName)
     {
-        BPakFileEncryption.SetKeyset(KeysetType.PC2AndAbove);
         var filePath = Path.Combine(_pakPath, fileName);
-        BPakFile.FromFile(filePath, withExtraInfo: true).UnpackAll(_extractedPath);
+        BPakFileEncryption.SetKeyset(KeysetType.PC2AndAbove);
+        using var pakFile = BPakFile.FromFile(filePath, withExtraInfo: true);
+        pakFile.UnpackAll(_extractedPath);
     }
 
     private string ExtractedPakPath(string name) =>

--- a/src/Core/Mods/GeneratedBootfiles.cs
+++ b/src/Core/Mods/GeneratedBootfiles.cs
@@ -34,7 +34,7 @@ public class GeneratedBootfiles : ExtractedMod
     {
         var filePath = Path.Combine(_pakPath, fileName);
         BPakFileEncryption.SetKeyset(KeysetType.PC2AndAbove);
-        using var pakFile = BPakFile.FromFile(filePath, withExtraInfo: true);
+        using var pakFile = BPakFile.FromFile(filePath, withExtraInfo: true, outputWriter: TextWriter.Null);
         pakFile.UnpackAll(_extractedPath);
     }
 

--- a/src/Core/Mods/GeneratedBootfiles.cs
+++ b/src/Core/Mods/GeneratedBootfiles.cs
@@ -11,6 +11,8 @@ public class GeneratedBootfiles : ExtractedMod
     private const string PhysicsPersistentPakFileName = "PHYSICSPERSISTENT.bff";
 
     private readonly string _pakPath;
+    private readonly string BmtFilesWildcard =
+        Path.Combine("vehicles", "_data", "effects", "backfire", "*.bmt");
 
     public GeneratedBootfiles(string gamePath, string generationBasePath)
         : base(VirtualPackageName, Path.Combine(generationBasePath, VirtualPackageName))
@@ -25,6 +27,7 @@ public class GeneratedBootfiles : ExtractedMod
         ExtractPakFileFromGame(PhysicsPersistentPakFileName);
         CreateEmptyPakFile("BOOTSPLASH", ExtractedPakPath(BootFlowPakFileName));
         CreateEmptyFile(ExtractedPakPath($"{PhysicsPersistentPakFileName}{JsgmeFileInstaller.RemoveFileSuffix}"));
+        DeleteExtractedFiles(BmtFilesWildcard);
     }
 
     private void ExtractPakFileFromGame(string fileName)
@@ -81,6 +84,14 @@ public class GeneratedBootfiles : ExtractedMod
         var parent = Path.GetDirectoryName(path);
         if (parent is not null)
             Directory.CreateDirectory(parent);
+    }
+
+    private void DeleteExtractedFiles(string wildcardRelative)
+    {
+        foreach (var file in Directory.EnumerateFiles(_extractedPath, wildcardRelative))
+        {
+            File.Delete(file);
+        }
     }
 
     protected override IMod.ConfigEntries GenerateConfig() => EmptyConfig;

--- a/src/Core/Mods/IMod.cs
+++ b/src/Core/Mods/IMod.cs
@@ -8,12 +8,15 @@ public interface IMod
     ConfigEntries Config { get; }
 
     void Install(string dstPath);
-    
+
     public record ConfigEntries(
         IReadOnlyCollection<string> CrdFileEntries,
         IReadOnlyCollection<string> TrdFileEntries,
         IReadOnlyCollection<string> DrivelineRecords
-    );
+    )
+    {
+        public bool NotEmpty() => CrdFileEntries.Any() || TrdFileEntries.Any() || DrivelineRecords.Any();
+    };
 
     public enum InstalledState
     {

--- a/src/Core/Mods/JsgmeFileInstaller.cs
+++ b/src/Core/Mods/JsgmeFileInstaller.cs
@@ -3,7 +3,7 @@
 public static class JsgmeFileInstaller
 {
     private const string BackupFileSuffix = ".orig";
-    private const string JsgmeRemoveFileSuffix = "-remove";
+    public const string RemoveFileSuffix = "-remove";
 
     private static readonly string[] ExcludeCopySuffix =
     {
@@ -55,8 +55,8 @@ public static class JsgmeFileInstaller
 
     private static (string, bool) NeedsRemoving(string filePath)
     {
-        return filePath.EndsWith(JsgmeRemoveFileSuffix) ?
-            (filePath.RemoveSuffix(JsgmeRemoveFileSuffix).Trim(), true) :
+        return filePath.EndsWith(RemoveFileSuffix) ?
+            (filePath.RemoveSuffix(RemoveFileSuffix).Trim(), true) :
             (filePath, false);
     }
 

--- a/src/Core/Mods/ManualInstallMod.cs
+++ b/src/Core/Mods/ManualInstallMod.cs
@@ -1,100 +1,22 @@
 ﻿namespace Core.Mods;
 
-public class ManualInstallMod : IMod
+public class ManualInstallMod : ExtractedMod
 {
-    private static readonly string[] DirsAtRootLowerCase =
-    {
-        "cameras",
-        "characters",
-        "effects",
-        "gui",
-        "pakfiles",
-        "render",
-        "text",
-        "tracks",
-        "upgrade",
-        "vehicles"
-    };
-    private const string ConfigExcludeModPrefix = "__";
     private static readonly string[] ConfigExcludeFile =
     {
         // IndyCar 2023
         "IR-18_2023_My_Team.crd",
         "IR-18_2023_Dale_Coyne_hr.crd"
     };
-    
-    private readonly string _extractedPath;
-    private readonly List<string> _installedFiles = new();
 
     public ManualInstallMod(string packageName, string extractedPath)
+        : base(packageName, extractedPath)
     {
-        PackageName = packageName;
-        Config = new IMod.ConfigEntries(Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>());
-        _extractedPath = extractedPath;
-    }
-
-    public string PackageName
-    {
-        get;
-    }
-
-    public IMod.InstalledState Installed
-    {
-        get;
-        private set;
     }
     
-    public IMod.ConfigEntries Config
-    {
-        get;
-        private set;
-    }
+    protected override IMod.ConfigEntries GenerateConfig() =>
+        new(CrdFileEntries(), TrdFileEntries(), FindDrivelineRecords());
 
-    public IReadOnlyCollection<string> InstalledFiles => _installedFiles;
-    
-    public void Install(string dstPath)
-    {
-        if (Installed != IMod.InstalledState.NotInstalled)
-        {
-            throw new InvalidOperationException();
-        }
-        Installed = IMod.InstalledState.PartiallyInstalled;
-
-        foreach (var rootPath in FindModRootDirs())
-        {
-            JsgmeFileInstaller.InstallFiles(rootPath, dstPath,
-                relativeFilePath => _installedFiles.Add(relativeFilePath));
-        }
-
-        if (!PackageName.StartsWith(ConfigExcludeModPrefix))
-        {
-            Config = new IMod.ConfigEntries(CrdFileEntries(), TrdFileEntries(), FindDrivelineRecords());
-        }
-        
-        Installed = IMod.InstalledState.Installed;
-    }
-
-    private IEnumerable<string> FindModRootDirs()
-    {
-        return FindRootContaining(_extractedPath, DirsAtRootLowerCase);
-    }
-    
-    private static List<string> FindRootContaining(string path, string[] contained)
-    {
-        var roots = new List<string>();
-        foreach (var subdir in Directory.GetDirectories(path))
-        {
-            var localName = Path.GetFileName(subdir).ToLowerInvariant();
-            if (contained.Contains(localName))
-            {
-                return new List<string> {path};
-            }
-            roots.AddRange(FindRootContaining(subdir, contained));
-        }
-
-        return roots;
-    }
-    
     private List<string> CrdFileEntries()
     {
         return _installedFiles


### PR DESCRIPTION
Closes #6.

If bootfiles are not needed, don't install them and skip post-processing. Otherwise do the first that match:
1. fail if multiple archives with the `__bootfiles` prefix in `Mods\Enabled`
2. install it if a single archive
3. generate bootfiles from game files and install them
