### PR TITLE
Load oo2core_4_win64 compression library

### DIFF
--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -13,7 +13,7 @@
     <ItemGroup>
         <PackageReference Include="Gameloop.Vdf" Version="0.6.2" />
         <PackageReference Include="Gameloop.Vdf.JsonConverter" Version="0.2.1" />
-        <PackageReference Include="PCarsTools" Version="1.1.2.4" />
+        <PackageReference Include="PCarsTools" Version="1.1.2.5" />
         <PackageReference Include="SevenZipExtractor" Version="1.0.17" />
     </ItemGroup>
 </Project>

--- a/src/Core/ModManager.cs
+++ b/src/Core/ModManager.cs
@@ -37,6 +37,9 @@ public class ModManager
         }
 
         var ams2InstallationDirectory = Path.Combine(ams2LibraryPath, Ams2InstallationDir);
+        // It shoulnd't be needed, but some systems seem to want to load oo2core
+        // even when Mermaid and Kraken compression are not used in pak files!
+        AddToEnvionmentPath(ams2InstallationDirectory);
         var modsDir = Path.Combine(ams2InstallationDirectory, ModsSubdir);
         var installPaths = new InstallPaths(
             ModArchivesPath: Path.Combine(modsDir, EnabledModsSubdir),
@@ -46,6 +49,12 @@ public class ModManager
         );
 
         return new ModManager(installPaths);
+    }
+
+    private static void AddToEnvionmentPath(string additionalPath)
+    {
+        var env = Environment.GetEnvironmentVariable("PATH");
+        Environment.SetEnvironmentVariable("PATH",  $"{env};{additionalPath}");
     }
 
     private ModManager(InstallPaths installPaths)


### PR DESCRIPTION
Some users have reported this error: `Unable to load DLL 'oo2core_7_win64'`. Cannot reproduce it; that library should be loaded only for Mermaid and Kraken compression algorithms, that are not used in my installation.

- Switch from `oo2core_7_win64` to `oo2core_4_win64` that is provided with the game
- Add game root to dll load path, to allow that directory to be loaded if needed
- Tested pointing AMS2CM to PC2's installation directory (that requires it)
