### PR TITLE
Cleanup temp directory

### DIFF
--- a/src/Core/ModManager.cs
+++ b/src/Core/ModManager.cs
@@ -13,10 +13,15 @@ public class ModManager
         string CurrentStateFile
     );
 
-    private static readonly string FileRemovedByBootfiles = Path.Combine("Pakfiles", "PHYSICSPERSISTENT.bff");
+    private static readonly string FileRemovedByBootfiles = Path.Combine(
+        GeneratedBootfiles.PakfilesDirectory,
+        GeneratedBootfiles.PhysicsPersistentPakFileName
+    );
 
-    private const string ModsSubdir = "Mods";
-    private const string EnabledModsSubdir = "Enabled";
+    private const string ModsDirName = "Mods";
+    private const string EnabledModsDirName = "Enabled";
+    private const string TempDirName = "Temp";
+    private const string CurrentStateFileName = "installed.json";
 
     private const string BootfilesPrefix = "__bootfiles";
 
@@ -30,22 +35,23 @@ public class ModManager
     {
         this.game = game;
         this.modFactory = modFactory;
-        var modsDir = Path.Combine(game.InstallationDirectory, ModsSubdir);
+        var modsDir = Path.Combine(game.InstallationDirectory, ModsDirName);
         workPaths = new WorkPaths(
-            ModArchivesDir: Path.Combine(modsDir, EnabledModsSubdir),
-            TempDir: Path.Combine(modsDir, "Temp"),
-            CurrentStateFile: Path.Combine(modsDir, "installed.json")
+            ModArchivesDir: Path.Combine(modsDir, EnabledModsDirName),
+            TempDir: Path.Combine(modsDir, TempDirName),
+            CurrentStateFile: Path.Combine(modsDir, CurrentStateFileName)
         );
     }
 
     private static void AddToEnvionmentPath(string additionalPath)
     {
-        var env = Environment.GetEnvironmentVariable("PATH");
+        const string pathEnvVar = "PATH";
+        var env = Environment.GetEnvironmentVariable(pathEnvVar);
         if (env is not null && env.Contains(additionalPath))
         {
             return;
         }
-        Environment.SetEnvironmentVariable("PATH", $"{env};{additionalPath}");
+        Environment.SetEnvironmentVariable(pathEnvVar, $"{env};{additionalPath}");
     }
 
     public void InstallEnabledMods()

--- a/src/Core/Mods/GeneratedBootfiles.cs
+++ b/src/Core/Mods/GeneratedBootfiles.cs
@@ -5,10 +5,10 @@ namespace Core.Mods;
 
 internal class GeneratedBootfiles : ExtractedMod
 {
-    private const string VirtualPackageName = "__bootfiles_generated";
-    private const string PakfilesDirectory = "Pakfiles";
-    private const string BootFlowPakFileName = "BOOTFLOW.bff";
-    private const string PhysicsPersistentPakFileName = "PHYSICSPERSISTENT.bff";
+    internal const string VirtualPackageName = "__bootfiles_generated";
+    internal const string PakfilesDirectory = "Pakfiles";
+    internal const string BootFlowPakFileName = "BOOTFLOW.bff";
+    internal const string PhysicsPersistentPakFileName = "PHYSICSPERSISTENT.bff";
 
     private readonly string pakPath;
     private readonly string BmtFilesWildcard =


### PR DESCRIPTION
Allows clean-up of the temporary directory when errors happen; they would previously be left there forever.

- Extract archives directly on the temp directory
- Delete the temp directory before (in case something was left there) and after
