### PR TITLE
Trim end of record lines

### DIFF
--- a/src/Core/Mods/ManualInstallMod.cs
+++ b/src/Core/Mods/ManualInstallMod.cs
@@ -92,7 +92,7 @@ public class ManualInstallMod : ExtractedMod
                     recordLines.Clear();
                     continue;
                 }
-                var lineNoIndent = line.Substring(recordIndent);
+                var lineNoIndent = line.Substring(recordIndent).TrimEnd();
                 recordLines.Add(lineNoIndent);
             }
 


### PR DESCRIPTION
Some users have reported game crashes when driveline records end with whitespaces: https://www.racedepartment.com/threads/indycar-ir18-2023-mod.256695/page-15#post-3678621

This should fix automatically those broken mods.
