### PR TITLE
Dedupe driveline records

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Install .NET Core
+    - name: Install .NET
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 6.0.x
@@ -34,6 +34,7 @@ jobs:
       run: |
         msbuild /t:Restore /p:Configuration=${{ matrix.configuration }}
         msbuild /t:Build /p:Configuration=${{ matrix.configuration }} /p:Platform=${{ matrix.platform }}
+        dotnet test --configuration ${{ matrix.configuration }} --arch ${{ matrix.platform }}
 
     - name: Upload license
       uses: actions/upload-artifact@v3

--- a/AMS2CM.sln
+++ b/AMS2CM.sln
@@ -9,6 +9,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Core", "src\Core\Core.cspro
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GUI", "src\GUI\GUI.csproj", "{2C96062E-2EDF-4BBE-8BC2-968B7A1F4EFE}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Core.Tests", "tests\Core.Tests\Core.Tests.csproj", "{C6534E1B-8131-46A6-B826-F669A0FDAAE3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -19,8 +21,12 @@ Global
 		{77400FE1-383E-4D92-9A7F-D4AEA8A1AE0C}.Debug|x64.Build.0 = Debug|x64
 		{77400FE1-383E-4D92-9A7F-D4AEA8A1AE0C}.Release|x64.ActiveCfg = Release|x64
 		{77400FE1-383E-4D92-9A7F-D4AEA8A1AE0C}.Release|x64.Build.0 = Release|x64
+		{A20048F0-D212-499D-8CCF-5E0B989E21F7}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{A20048F0-D212-499D-8CCF-5E0B989E21F7}.Debug|Any CPU.Build.0 = Debug|x64
 		{A20048F0-D212-499D-8CCF-5E0B989E21F7}.Debug|x64.ActiveCfg = Debug|x64
 		{A20048F0-D212-499D-8CCF-5E0B989E21F7}.Debug|x64.Build.0 = Debug|x64
+		{A20048F0-D212-499D-8CCF-5E0B989E21F7}.Release|Any CPU.ActiveCfg = Release|x64
+		{A20048F0-D212-499D-8CCF-5E0B989E21F7}.Release|Any CPU.Build.0 = Release|x64
 		{A20048F0-D212-499D-8CCF-5E0B989E21F7}.Release|x64.ActiveCfg = Release|x64
 		{A20048F0-D212-499D-8CCF-5E0B989E21F7}.Release|x64.Build.0 = Release|x64
 		{2C96062E-2EDF-4BBE-8BC2-968B7A1F4EFE}.Debug|x64.ActiveCfg = Debug|x64
@@ -29,6 +35,14 @@ Global
 		{2C96062E-2EDF-4BBE-8BC2-968B7A1F4EFE}.Release|x64.ActiveCfg = Release|x64
 		{2C96062E-2EDF-4BBE-8BC2-968B7A1F4EFE}.Release|x64.Build.0 = Release|x64
 		{2C96062E-2EDF-4BBE-8BC2-968B7A1F4EFE}.Release|x64.Deploy.0 = Release|x64
+		{C6534E1B-8131-46A6-B826-F669A0FDAAE3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C6534E1B-8131-46A6-B826-F669A0FDAAE3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C6534E1B-8131-46A6-B826-F669A0FDAAE3}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C6534E1B-8131-46A6-B826-F669A0FDAAE3}.Debug|x64.Build.0 = Debug|Any CPU
+		{C6534E1B-8131-46A6-B826-F669A0FDAAE3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C6534E1B-8131-46A6-B826-F669A0FDAAE3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C6534E1B-8131-46A6-B826-F669A0FDAAE3}.Release|x64.ActiveCfg = Release|Any CPU
+		{C6534E1B-8131-46A6-B826-F669A0FDAAE3}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -11,6 +11,12 @@
     </PropertyGroup>
 
 	<ItemGroup>
+		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+			<_Parameter1>Core.Tests</_Parameter1>
+		</AssemblyAttribute>
+	</ItemGroup>
+
+	<ItemGroup>
 		<PackageReference Include="GitVersion.MsBuild" Version="5.12.*">
 			<PrivateAssets>All</PrivateAssets>
 		</PackageReference>

--- a/src/Core/Mods/PostProcessor.cs
+++ b/src/Core/Mods/PostProcessor.cs
@@ -50,19 +50,21 @@ internal static class PostProcessor
         File.WriteAllText(driveLineFilePath, newContents);
     }
 
-    private static IEnumerable<string> DedupeRecordBlocks(IEnumerable<string> recordBlocks)
+    internal static IEnumerable<string> DedupeRecordBlocks(IEnumerable<string> recordBlocks)
     {
-        var deduped = new Dictionary<string, string>();
+        var seen = new HashSet<string>();
+        var deduped = new List<string>();
         foreach (var rb in recordBlocks.Reverse())
         {
             var key = rb.Split(Environment.NewLine, 2).First().NormalizeWhitespaces();
-            if (deduped.ContainsKey(key))
+            if (seen.Contains(key))
             {
                 continue;
             }
-            deduped.Add(key, rb);
+            seen.Add(key);
+            deduped.Add(rb);
         }
-        return deduped.Values;
+        return deduped.Reverse<string>();
     }
 
     private static string WrapInComments(string content)

--- a/src/Core/Utils/StringExtensions.cs
+++ b/src/Core/Utils/StringExtensions.cs
@@ -1,9 +1,14 @@
-﻿namespace Core.Utils;
+﻿using System.Text.RegularExpressions;
+
+namespace Core.Utils;
 
 public static class StringExtensions
 {
-    public static string RemoveSuffix(this string s, string suffix)
-    {
-        return s.EndsWith(suffix) ? s[..^suffix.Length] : s;
-    }
+    public static string RemoveSuffix(this string s, string suffix) =>
+        s.EndsWith(suffix) ? s[..^suffix.Length] : s;
+
+    private static readonly Regex whitespacesRegex = new(@"\s+");
+
+    public static string NormalizeWhitespaces(this string s) =>
+        whitespacesRegex.Replace(s, " ").Trim();
 }

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>$(MSBuildProjectName).Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+</Project>

--- a/tests/Core.Tests/Core.Tests.csproj
+++ b/tests/Core.Tests/Core.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net6.0-windows</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<IsPackable>false</IsPackable>
+		<IsTestProject>true</IsTestProject>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\..\src\Core\Core.csproj" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+		<PackageReference Include="xunit" Version="2.4.2" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="coverlet.collector" Version="3.2.0">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+	</ItemGroup>
+
+</Project>

--- a/tests/Core.Tests/Mods/PostProcessorTest.cs
+++ b/tests/Core.Tests/Mods/PostProcessorTest.cs
@@ -1,0 +1,66 @@
+using Core.Mods;
+
+namespace Core.Tests.Mods;
+
+public class PostProcessorTest
+{
+    [Fact]
+    public void DedupeRecordBlocks_ConsidersOnlyFirstLine()
+    {
+        Assert.Equal(new[]
+        {
+            @"RECORDGROUP foo
+                last"
+        },
+        PostProcessor.DedupeRecordBlocks(new []
+        {
+            @"RECORDGROUP foo
+                first",
+            @"RECORDGROUP foo
+                last"
+        }));
+    }
+
+    [Fact]
+    public void DedupeRecordBlocks_IgnoresRedundantWhitespaces()
+    {
+        Assert.Equal(new[]
+        {
+            "RECORD foo\tbar"
+        },
+        PostProcessor.DedupeRecordBlocks(new[]
+        {
+            "  RECORD foo\vbar ",
+            "RECORD foo\tbar"
+        }));
+    }
+
+    [Fact]
+    public void DedupeRecordBlocks_WorksForEmptyLines()
+    {
+        Assert.Equal(new[]
+        {
+            ""
+        },
+        PostProcessor.DedupeRecordBlocks(new[]
+        {
+            "",
+            "",
+        }));
+    }
+
+    [Fact]
+    public void DedupeRecordBlocks_AssumesCommentsAlreadyRemoved()
+    {
+        Assert.Equal(new[]
+        {
+            @"RECORD foo bar # first",
+            @"RECORD foo bar # last"
+        },
+        PostProcessor.DedupeRecordBlocks(new[]
+        {
+            @"RECORD foo bar # first",
+            @"RECORD foo bar # last"
+        }));
+    }
+}

--- a/tests/Core.Tests/Usings.cs
+++ b/tests/Core.Tests/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/tests/Core.Tests/Utils/StringExtensionsTest.cs
+++ b/tests/Core.Tests/Utils/StringExtensionsTest.cs
@@ -2,10 +2,10 @@ namespace Core.Tests.Utils;
 
 using static Core.Utils.StringExtensions;
 
-public class StringExtensionsTest
+public class PostProcessorTest
 {
     [Fact]
-    public void NormalizeWhitespacesReplacesWithSpaces()
+    public void NormalizeWhitespaces_ReplacesWithSpaces()
     {
         Assert.Equal("", "".NormalizeWhitespaces());
         Assert.Equal("foo bar", "foo bar".NormalizeWhitespaces());
@@ -13,7 +13,7 @@ public class StringExtensionsTest
     }
 
     [Fact]
-    public void NormalizeWhitespacesTrimsInput()
+    public void NormalizeWhitespaces_TrimsInput()
     {
         Assert.Equal("foo", " foo\f".NormalizeWhitespaces());
     }

--- a/tests/Core.Tests/Utils/StringExtensionsTest.cs
+++ b/tests/Core.Tests/Utils/StringExtensionsTest.cs
@@ -1,0 +1,20 @@
+namespace Core.Tests.Utils;
+
+using static Core.Utils.StringExtensions;
+
+public class StringExtensionsTest
+{
+    [Fact]
+    public void NormalizeWhitespacesReplacesWithSpaces()
+    {
+        Assert.Equal("", "".NormalizeWhitespaces());
+        Assert.Equal("foo bar", "foo bar".NormalizeWhitespaces());
+        Assert.Equal("foo bar", "foo\r\v\nbar".NormalizeWhitespaces());
+    }
+
+    [Fact]
+    public void NormalizeWhitespacesTrimsInput()
+    {
+        Assert.Equal("foo", " foo\f".NormalizeWhitespaces());
+    }
+}


### PR DESCRIPTION
Some mods come with duplicate driveline records. While it works, it's not desirable.
- Keep the last `RECORD` or `RECORDGROUP` defined, in mod installation order.
- It compares the first line, trimmed and with all whitespaces normalised into a single space.