### PR TITLE
Fix progress bar edge cases

### DIFF
--- a/src/Core/Utils/Percent.cs
+++ b/src/Core/Utils/Percent.cs
@@ -1,0 +1,20 @@
+﻿namespace Core.Utils;
+
+public class Percent
+{
+    private readonly double total;
+    private double done;
+
+    public static Percent OfTotal(int total) => new(total);
+
+    private Percent(double total)
+    {
+        this.total = total;
+    }
+
+    public double Increment()
+    {
+        done += 1.0;
+        return done / total;
+    }
+}


### PR DESCRIPTION
- Progress bar stays in undetermined state when there is nothing to install.
- Consider bootfiles as extra mod to avoid 100% when extracting it.