### PR TITLE
Remove unused platform runtimes

### DIFF
--- a/src/GUI/GUI.csproj
+++ b/src/GUI/GUI.csproj
@@ -71,4 +71,9 @@
 		<Move SourceFiles="$(OutDir)\x64\7z.dll" DestinationFiles="$(OutDir)\7z64.dll" />
 		<RemoveDir Directories="$(OutDir)\x86;$(OutDir)\x64" />
 	</Target>
+
+	<!-- Remove files for unsupported platforms -->
+	<Target Name="RemoveUnsupportedPlatformFiles" AfterTargets="Build">
+		<RemoveDir Directories="$(OutDir)\runtimes\win10-arm64;$(OutDir)\runtimes\win10-x86" />
+	</Target>
 </Project>


### PR DESCRIPTION
`runtimes/win10-arm64` and  `runtimes/win10-x86` are not needed in the output, since we only support x64 (like the game).