### PR TITLE
Display progress bar when adding or deleting mods

### DIFF
--- a/src/Core/ModManager.cs
+++ b/src/Core/ModManager.cs
@@ -6,7 +6,6 @@ using Core.State;
 using SevenZip;
 using static Core.IModManager;
 using static Core.Mods.JsgmeFileInstaller;
-using System.IO;
 
 namespace Core;
 

--- a/src/Core/Utils/EnumerableExtensions.cs
+++ b/src/Core/Utils/EnumerableExtensions.cs
@@ -1,9 +1,13 @@
-﻿using YamlDotNet.Core.Tokens;
-
-namespace Core.Utils;
+﻿namespace Core.Utils;
 
 public static class EnumerableExtensions
 {
     public static IEnumerable<(T item, int index)> WithIndex<T>(this IEnumerable<T> self) =>
         self.Select((item, index) => (item, index));
+
+    public static IEnumerable<TOut> SelectNotNull<TIn, TOut>(this IEnumerable<TIn> self, Func<TIn, TOut?> selector) =>
+        self.SelectMany(_ => {
+            var i = selector(_);
+            return i is null ? Enumerable.Empty<TOut>() : Enumerable.Repeat(i, 1);
+        });
 }

--- a/src/GUI/MainWindow.xaml.cs
+++ b/src/GUI/MainWindow.xaml.cs
@@ -7,6 +7,7 @@ using Windows.Storage;
 using WinUIEx;
 using Windows.Storage.Pickers;
 using Core.Utils;
+using System.Collections;
 
 namespace AMS2CM.GUI;
 
@@ -83,11 +84,17 @@ public sealed partial class MainWindow : WindowEx
 
     private async void ModListView_DragItemsStarting(object sender, Microsoft.UI.Xaml.Controls.DragItemsStartingEventArgs e)
     {
-        var storageItems = new List<StorageFile>();
-        foreach (var o in e.Items)
+        var filePaths = e.Items.OfType<ModVM>().SelectNotNull(_ => _.PackagePath);
+        if (!filePaths.Any())
         {
-            var mvm = (ModVM)o;
-            var si = await StorageFile.GetFileFromPathAsync(mvm.PackagePath);
+            e.Cancel = true;
+            return;
+        }
+
+        var storageItems = new List<StorageFile>();
+        foreach (var filePath in filePaths)
+        {
+            var si = await StorageFile.GetFileFromPathAsync(filePath);
             storageItems.Add(si);
         }
         e.Data.SetStorageItems(storageItems);

--- a/src/GUI/MainWindow.xaml.cs
+++ b/src/GUI/MainWindow.xaml.cs
@@ -7,7 +7,6 @@ using Windows.Storage;
 using WinUIEx;
 using Windows.Storage.Pickers;
 using Core.Utils;
-using System.Collections;
 
 namespace AMS2CM.GUI;
 
@@ -166,36 +165,28 @@ public sealed partial class MainWindow : WindowEx
             return;
         }
 
-        await SyncDialog.ShowAsync(Content.XamlRoot, (dialog, cancellationToken) =>
-        {
-            var filesToInstall = filePaths.ToList();
-            var progress = Percent.OfTotal(filesToInstall.Count);
-            foreach (var filePath in filesToInstall)
+        await SyncDialog.ShowAsync(Content.XamlRoot, filePaths, (dialog, filePath) =>
             {
-                if (cancellationToken.IsCancellationRequested)
-                {
-                    break;
-                }
                 modManager.AddNewMod(filePath);
                 dialog.LogMessage(Path.GetFileName(filePath));
-                dialog.SetProgress(progress.Increment());
-            }
-            return true;
-        });
+            });
+
         SyncModListView();
     }
 
-    private void DeleteMods(IEnumerable<string> filePaths)
+    private async void DeleteMods(IEnumerable<string> filePaths)
     {
         if (!filePaths.Any())
         {
             return;
         }
 
-        foreach (var filePath in filePaths)
+        await SyncDialog.ShowAsync(Content.XamlRoot, filePaths, (dialog, filePath) =>
         {
-            FileSystem.DeleteFile(filePath, UIOption.AllDialogs, RecycleOption.SendToRecycleBin);
-        }
+            FileSystem.DeleteFile(filePath, UIOption.OnlyErrorDialogs, RecycleOption.SendToRecycleBin);
+            dialog.LogMessage(Path.GetFileName(filePath));
+        });
+
         SyncModListView();
     }
 }


### PR DESCRIPTION
The UI hangs until mods are added in any way or deleted without drag and drop (otherwise Windows Explorer will display the usual move dialog). For slow systems, this can appear like an error.

- This introduces a dialog with a progress bar, like for synchronisation, but that will close automatically on success.
- It also fixes a bug where already removed mods could be dragged, resulting in an error.

Notes:
- It is not trivial, but it would be good, to display the dialog only if it takes more than a few seconds (like Windows does) or in case of errors.