### PR TITLE
Support new AMS2 1.5 mods

### DIFF
--- a/src/Core/Mods/ManualInstallMod.cs
+++ b/src/Core/Mods/ManualInstallMod.cs
@@ -4,6 +4,8 @@ namespace Core.Mods;
 
 public class ManualInstallMod : ExtractedMod
 {
+    private static readonly string GameSupportedModDirectory = Path.Combine("UserData", "Mods");
+
     public interface IConfig
     {
         IEnumerable<string> DirsAtRoot { get; }
@@ -49,8 +51,15 @@ public class ManualInstallMod : ExtractedMod
         return roots;
     }
 
-    protected override IMod.ConfigEntries GenerateConfig() =>
-        new(CrdFileEntries(), TrdFileEntries(), FindDrivelineRecords());
+    protected override IMod.ConfigEntries GenerateConfig()
+    {
+        var gameSupportedMod = FileEntriesToConfigure()
+            .Where(p => p.StartsWith(GameSupportedModDirectory))
+            .Any();
+        return gameSupportedMod
+            ? new(Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>())
+            : new(CrdFileEntries(), TrdFileEntries(), FindDrivelineRecords());
+    }
 
     private List<string> CrdFileEntries() =>
         FileEntriesToConfigure()


### PR DESCRIPTION
- New style mods
  - Are detected by the presence of a `UserData\Mods` directory
  - Are configured by the game so don't need bootfiles extraction and configuration
- Old style mods
  - Are still supported
  - Are configured after extracting bootfiles
