### PR TITLE
Show error when adding directories

### DIFF
--- a/src/Core/ModManager.cs
+++ b/src/Core/ModManager.cs
@@ -99,6 +99,12 @@ internal class ModManager : IModManager
     public ModState AddNewMod(string packageFullPath)
     {
         var fileName = Path.GetFileName(packageFullPath);
+
+        if (IsDirectory(packageFullPath))
+        {
+            throw new Exception($"{fileName} is a directory");
+        }
+
         var isDisabled = ListDisabledModPackages().Where(_ => _.PackageName == fileName).Any();
         var destinationDirectoryPath = isDisabled ? workPaths.DisabledModArchivesDir : workPaths.EnabledModArchivesDir;
         var destinationFilePath = Path.Combine(destinationDirectoryPath, fileName);
@@ -116,6 +122,9 @@ internal class ModManager : IModManager
                 IsInstalled: false
             );
     }
+
+    private bool IsDirectory(string path) =>
+        File.GetAttributes(path).HasFlag(FileAttributes.Directory);
 
     public string EnableMod(string packagePath)
     {

--- a/src/GUI/MainWindow.xaml.cs
+++ b/src/GUI/MainWindow.xaml.cs
@@ -76,8 +76,7 @@ public sealed partial class MainWindow : WindowEx
         if (e.DataView.Contains(StandardDataFormats.StorageItems))
         {
             var storageItems = await e.DataView.GetStorageItemsAsync();
-            var filePaths = storageItems.OfType<StorageFile>().Select(_ => _.Path);
-            AddNewMods(filePaths);
+            AddNewMods(storageItems.Select(_ => _.Path));
         }
     }
 


### PR DESCRIPTION
Some users, especially coming from JSGME, try to drag and drop directories instead of files. Drag and drop would simply ignore those and they wouldn't get any error.

This is how it looks instead with this change:

![image](https://github.com/OpenSimTools/AMS2CM/assets/188185/db86dc00-fe42-46fc-9409-66736cce6ffa)
