### PR TITLE
Exclude installation of potentially malicious files

### DIFF
--- a/src/Core/Config.cs
+++ b/src/Core/Config.cs
@@ -37,5 +37,6 @@ public class GameConfig : Game.IConfig
 public class ModInstallConfig : ModFactory.IConfig
 {
     public IEnumerable<string> DirsAtRoot { get; set; } = Array.Empty<string>();
+    public IEnumerable<string> ExcludedFromInstall { get; set; } = Array.Empty<string>();
     public IEnumerable<string> ExcludedFromConfig { get; set; } = Array.Empty<string>();
 }

--- a/src/Core/Mods/ExtractedMod.cs
+++ b/src/Core/Mods/ExtractedMod.cs
@@ -46,7 +46,9 @@ public abstract class ExtractedMod : IMod
         foreach (var rootPath in ExtractedRootDirs())
         {
             JsgmeFileInstaller.InstallFiles(rootPath, dstPath,
-                beforeFileCallback,
+                relativePath =>
+                    FileShouldBeInstalled(relativePath) &&
+                    beforeFileCallback(relativePath),
                 relativePath =>
                 {
                     installedFiles.Add(relativePath);
@@ -67,4 +69,6 @@ public abstract class ExtractedMod : IMod
     protected abstract IEnumerable<string> ExtractedRootDirs();
 
     protected abstract IMod.ConfigEntries GenerateConfig();
+
+    protected virtual bool FileShouldBeInstalled(string relativePath) => true;
 }

--- a/src/Core/Mods/ManualInstallMod.cs
+++ b/src/Core/Mods/ManualInstallMod.cs
@@ -9,9 +9,11 @@ public class ManualInstallMod : ExtractedMod
     public interface IConfig
     {
         IEnumerable<string> DirsAtRoot { get; }
+        IEnumerable<string> ExcludedFromInstall { get; }
         IEnumerable<string> ExcludedFromConfig { get; }
     }
 
+    private readonly Matcher filesToInstallMatcher;
     private readonly Matcher filesToConfigureMatcher;
     private readonly List<string> dirsAtRootLowerCase;
 
@@ -19,6 +21,7 @@ public class ManualInstallMod : ExtractedMod
         : base(packageName, extractedPath)
     {
         dirsAtRootLowerCase = config.DirsAtRoot.Select(dir => dir.ToLowerInvariant()).ToList();
+        filesToInstallMatcher = MatcherExcluding(config.ExcludedFromInstall);
         filesToConfigureMatcher = MatcherExcluding(config.ExcludedFromConfig);
     }
 
@@ -113,4 +116,7 @@ public class ManualInstallMod : ExtractedMod
 
         return recordBlocks;
     }
+
+    protected override bool FileShouldBeInstalled(string relativePath) =>
+        filesToInstallMatcher.Match(relativePath).HasMatches;
 }

--- a/src/Shared/Config.yaml
+++ b/src/Shared/Config.yaml
@@ -15,6 +15,9 @@ ModInstall:
   - userdata
   - upgrade
   - vehicles
+  ExcludedFromInstall:
+  - '**\*.dll'
+  - '**\*.exe'
   ExcludedFromConfig:
   # IndyCar 2023 1.0 Fix
   - '**\IR-18_2023_Dale_Coyne_hr.crd'


### PR DESCRIPTION
Close #94.

- Configure file patterns that are permanently excluded from installation
- Default exclusion for dll and exe files (case insensitive)
