### PR TITLE
Keep track of mod updates

### DIFF
--- a/src/Core/ModState.cs
+++ b/src/Core/ModState.cs
@@ -5,5 +5,6 @@ public record ModState(
     string PackageName,
     string? PackagePath,
     bool? IsInstalled, // null is partial
-    bool IsEnabled
+    bool IsEnabled,
+    bool IsOutOfDate
 );

--- a/src/Core/State/InternalState.cs
+++ b/src/Core/State/InternalState.cs
@@ -23,6 +23,10 @@ internal record InternalInstallationState(
 };
 
 internal record InternalModInstallationState(
+    // Unknown when partially installed or upgrading from a previous version
+    string? Hash,
+    // TODO: needed for backward compatibility
+    // infer from null hash after the first install
     bool Partial,
     IReadOnlyCollection<string> Files
 );

--- a/src/Core/State/InternalState.cs
+++ b/src/Core/State/InternalState.cs
@@ -24,7 +24,7 @@ internal record InternalInstallationState(
 
 internal record InternalModInstallationState(
     // Unknown when partially installed or upgrading from a previous version
-    string? Hash,
+    int? FsHash,
     // TODO: needed for backward compatibility
     // infer from null hash after the first install
     bool Partial,

--- a/src/Core/State/JsonFileStatePersistence.cs
+++ b/src/Core/State/JsonFileStatePersistence.cs
@@ -42,7 +42,7 @@ internal class JsonFileStatePersistence : IStatePersistence
                     Time: installTime,
                     Mods: oldState.AsEnumerable().ToDictionary(
                         kv => kv.Key,
-                        kv => new InternalModInstallationState(Partial: false, Files: kv.Value)
+                        kv => new InternalModInstallationState(Hash: null, Partial: false, Files: kv.Value)
                     )
                 )
             );

--- a/src/Core/State/JsonFileStatePersistence.cs
+++ b/src/Core/State/JsonFileStatePersistence.cs
@@ -42,7 +42,7 @@ internal class JsonFileStatePersistence : IStatePersistence
                     Time: installTime,
                     Mods: oldState.AsEnumerable().ToDictionary(
                         kv => kv.Key,
-                        kv => new InternalModInstallationState(Hash: null, Partial: false, Files: kv.Value)
+                        kv => new InternalModInstallationState(FsHash: null, Partial: false, Files: kv.Value)
                     )
                 )
             );

--- a/src/Core/Utils/DictionaryExtensions.cs
+++ b/src/Core/Utils/DictionaryExtensions.cs
@@ -17,8 +17,20 @@ public static class DictionaryExtensions
     }
 
     public static IReadOnlyDictionary<TKey, TValueOut> SelectValues<TKey, TValueIn, TValueOut>(this IReadOnlyDictionary<TKey, TValueIn> dict, Func<TValueIn, TValueOut> f)
-    where TKey : notnull
+        where TKey : notnull
     {
         return dict.ToDictionary(kv => kv.Key, kv => f(kv.Value));
+    }
+
+    public static IDictionary<TKey, TValueOut> SelectValues<TKey, TValueIn, TValueOut>(this IDictionary<TKey, TValueIn> dict, Func<TKey, TValueIn, TValueOut> f)
+        where TKey : notnull
+    {
+        return dict.ToDictionary(kv => kv.Key, kv => f(kv.Key, kv.Value));
+    }
+
+    public static IReadOnlyDictionary<TKey, TValueOut> SelectValues<TKey, TValueIn, TValueOut>(this IReadOnlyDictionary<TKey, TValueIn> dict, Func<TKey, TValueIn, TValueOut> f)
+        where TKey : notnull
+    {
+        return dict.ToDictionary(kv => kv.Key, kv => f(kv.Key, kv.Value));
     }
 }

--- a/src/GUI/MainWindow.xaml
+++ b/src/GUI/MainWindow.xaml
@@ -21,9 +21,10 @@
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="40"/>
             <ColumnDefinition Width="40"/>
+            <ColumnDefinition Width="40"/>
             <ColumnDefinition Width="*"/>
         </Grid.ColumnDefinitions>
-        <RichTextBlock Grid.ColumnSpan="3"
+        <RichTextBlock Grid.ColumnSpan="4"
             x:Name="NewVersionBlock"
             Margin="18,10,14,10"
             Visibility="Collapsed"
@@ -41,7 +42,7 @@
             Margin="15,10,0,10"
             Symbol="Import"
             ToolTipService.ToolTip="To Install"/>
-        <ScrollViewer Grid.Row="2" Grid.ColumnSpan="3">
+        <ScrollViewer Grid.Row="2" Grid.ColumnSpan="4">
             <ListView
                 x:Name="ModListView"
                 SelectionMode="Extended"
@@ -71,6 +72,7 @@
                                 <ColumnDefinition Width="40"/>
                                 <ColumnDefinition Width="40"/>
                                 <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="40"/>
                             </Grid.ColumnDefinitions>
                             <CheckBox
                                 MinWidth="0"
@@ -89,6 +91,10 @@
                                 VerticalAlignment="Center"
                                 Text="{x:Bind Name}"
                                 ToolTipService.ToolTip="{x:Bind PackageName}"/>
+                            <SymbolIcon Grid.Column="3"
+                                Visibility="{x:Bind IsOutOfDate}"
+                                Symbol="Refresh"
+                                ToolTipService.ToolTip="Out of date"/>
                         </Grid>
                     </DataTemplate>
                 </ListView.ItemTemplate>
@@ -96,7 +102,7 @@
         </ScrollViewer>
         <SplitButton
                 Content="Apply"
-                Grid.Row="3" Grid.ColumnSpan="3"
+                Grid.Row="3" Grid.ColumnSpan="4"
                 Margin="18,10,14,10"
                 HorizontalAlignment="Center"
                 VerticalAlignment="Center"

--- a/src/GUI/ModVM.cs
+++ b/src/GUI/ModVM.cs
@@ -28,6 +28,8 @@ internal class ModVM : INotifyPropertyChanged
 
     public bool? IsInstalled => modState.IsInstalled;
 
+    public bool IsOutOfDate => isEnabled; // TODO
+
     public bool IsEnabled
     {
         get => isEnabled;

--- a/src/GUI/ModVM.cs
+++ b/src/GUI/ModVM.cs
@@ -8,6 +8,7 @@ internal class ModVM : INotifyPropertyChanged
     private readonly ModState modState;
     private readonly IModManager modManager;
     private bool isEnabled;
+    private readonly bool isOutOfDate;
     private string? packagePath;
 
     public event PropertyChangedEventHandler? PropertyChanged;
@@ -18,6 +19,7 @@ internal class ModVM : INotifyPropertyChanged
         this.modManager = modManager;
         isEnabled = modState.IsEnabled;
         packagePath = modState.PackagePath;
+        isOutOfDate = modState.IsOutOfDate;
     }
 
     public string Name => modState.ModName;
@@ -28,7 +30,7 @@ internal class ModVM : INotifyPropertyChanged
 
     public bool? IsInstalled => modState.IsInstalled;
 
-    public bool IsOutOfDate => isEnabled; // TODO
+    public bool IsOutOfDate => isOutOfDate;
 
     public bool IsEnabled
     {


### PR DESCRIPTION
Closes #92.

- Use file hash to detect updates
  - [x] Store installed hash
    - After installation
    - From modification timestamp and size
    - Optional for backward- (not present) and forward- (different name) compatibility
  - [x] Read but not store available hash
- Show out of date mods in the UI
  - [x] Add out of date icon
  - [x] Use out-of-date information from mod hash (available vs installed)

Out of scope for this:
- ~Two-level hash with hash of modification timestamp and size of files (consider file order)~ Store content hash (from modification timestamp and size of files) for both available and installed mod
  - File hash only for available to know if the content hash has changed since last checked
  - Only for installed mods
  - Store after installation and if changed on fetch
- ~Versioned (split hasher and hash algorithm with name)~ (no need for this as the hash would change if different and we would consider it changed even between different hash versions)
