### PR TITLE
Upgrade .NET

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ jobs:
     - name: Install .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 8.0.x
     - name: Setup MSBuild
       uses: microsoft/setup-msbuild@v2
     - name: Configure NuGet repository
@@ -43,7 +43,7 @@ jobs:
       with:
         name: AMS2CM CLI
         path: |
-            src/CLI/bin/${{ matrix.platform }}/${{ matrix.configuration }}/net6.0-windows/**
+            src/CLI/bin/${{ matrix.platform }}/${{ matrix.configuration }}/net8.0-windows/**
             LICENSE
         if-no-files-found: error
     # Separate package until stable, to be able to release CLI independently

--- a/src/CLI/CLI.csproj
+++ b/src/CLI/CLI.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net6.0-windows</TargetFramework>
+		<TargetFramework>net8.0-windows</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<Company>OpenSimTools</Company>

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net6.0-windows</TargetFramework>
+        <TargetFramework>net8.0-windows</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <Company>OpenSimTools</Company>
@@ -26,8 +26,8 @@
         <PackageReference Include="Gameloop.Vdf" Version="0.6.2" />
         <PackageReference Include="Gameloop.Vdf.JsonConverter" Version="0.2.1" />
         <PackageReference Include="PCarsTools" Version="1.1.2.5" />
-        <PackageReference Include="Squid-Box.SevenZipSharp.Lite" Version="1.6.1.23" />
-        <PackageReference Include="Octokit" Version="10.0.0" />
+        <PackageReference Include="Squid-Box.SevenZipSharp.Lite" Version="1.6.2.24" />
+        <PackageReference Include="Octokit" Version="11.0.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/GUI/GUI.csproj
+++ b/src/GUI/GUI.csproj
@@ -9,8 +9,8 @@
 		<Authors>OpenSimTools Contributors</Authors>
 		<AssemblyName>AMS2CM.GUI</AssemblyName>
 		<RootNamespace>AMS2CM.GUI</RootNamespace>
-		<ApplicationManifest>app.manifest</ApplicationManifest>
 		<Platforms>x64</Platforms>
+		<PublishProfile>win-$(Platform).pubxml</PublishProfile>
 		<RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
 		<UseWinUI>true</UseWinUI>
 		<WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
@@ -28,7 +28,6 @@
 		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.5.240404000" />
 		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.3233" />
 		<PackageReference Include="WinUIEx" Version="2.3.4" />
-		<Manifest Include="$(ApplicationManifest)" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/GUI/GUI.csproj
+++ b/src/GUI/GUI.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<OutputType>WinExe</OutputType>
-		<TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+		<TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
 		<TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
@@ -11,7 +11,7 @@
 		<RootNamespace>AMS2CM.GUI</RootNamespace>
 		<ApplicationManifest>app.manifest</ApplicationManifest>
 		<Platforms>x64</Platforms>
-		<RuntimeIdentifiers>win10-x64</RuntimeIdentifiers>
+		<RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
 		<UseWinUI>true</UseWinUI>
 		<WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
 		<ApplicationIcon>..\Shared\AMS2CM.ico</ApplicationIcon>
@@ -25,9 +25,9 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\Core\Core.csproj" />
-		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.2.221109.1" />
+		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.5.240404000" />
 		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.3233" />
-		<PackageReference Include="WinUIEx" Version="2.1.0" />
+		<PackageReference Include="WinUIEx" Version="2.3.4" />
 		<Manifest Include="$(ApplicationManifest)" />
 	</ItemGroup>
 

--- a/src/Installer/Installer.wixproj
+++ b/src/Installer/Installer.wixproj
@@ -12,7 +12,7 @@
 	<ItemGroup>
 		<ProjectReference Include="..\CLI\CLI.csproj" />
 		<ProjectReference Include="..\GUI\GUI.csproj" />
-		<HarvestDirectory Include="..\GUI\bin\x64\$(Configuration)\net6.0-windows10.0.19041.0\">
+		<HarvestDirectory Include="..\GUI\bin\x64\$(Configuration)\net8.0-windows10.0.19041.0\">
 			<PreprocessorVariable>var.GUI.TargetDir</PreprocessorVariable>
 			<ComponentGroupName>GUI</ComponentGroupName>
 			<DirectoryRefId>APPLICATIONFOLDER</DirectoryRefId>

--- a/tests/Core.Tests/Core.Tests.csproj
+++ b/tests/Core.Tests/Core.Tests.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0-windows</TargetFramework>
+		<TargetFramework>net8.0-windows</TargetFramework>
 		<Platforms>x64</Platforms>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
@@ -15,12 +15,12 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-		<PackageReference Include="xunit" Version="2.7.0" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+		<PackageReference Include="xunit" Version="2.7.1" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.8">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="6.0.1">
+		<PackageReference Include="coverlet.collector" Version="6.0.2">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>


### PR DESCRIPTION
Closes #112.

- Upgrade to .NET 8
- Updated most dependencies except Wix (major version)