### PR TITLE
Better messaging for Steam errors

### DIFF
--- a/src/Core/Games/Game.cs
+++ b/src/Core/Games/Game.cs
@@ -26,14 +26,14 @@ public class Game : IGame
 
     public Game(IConfig config)
     {
-        var maybeInsallationDirectory = FindInstallationDirectory(config);
-        if (maybeInsallationDirectory is null || !Directory.Exists(maybeInsallationDirectory))
+        var insallationDirectory = FindInstallationDirectory(config);
+        if (!Directory.Exists(insallationDirectory))
         {
-            throw new Exception("Cannot find game directory");
+            throw new Exception("The game directory does not exist");
         }
 
         this.config = config;
-        InstallationDirectory = maybeInsallationDirectory;
+        InstallationDirectory = insallationDirectory;
     }
 
     public string InstallationDirectory
@@ -44,13 +44,13 @@ public class Game : IGame
 
     public bool IsRunning => Process.GetProcesses().Any(_ => _.ProcessName == config.ProcessName);
 
-    private static string? FindInstallationDirectory(IConfig config)
+    private static string FindInstallationDirectory(IConfig config)
     {
         if (Path.IsPathFullyQualified(config.Path))
         {
             return config.Path;
         }
-        var gameLibraryPath = Steam.AppLibraryPath(config.SteamId);
-        return gameLibraryPath is null ? null : Path.Combine(gameLibraryPath, config.Path);
+        var steamLibraryPath = Steam.AppLibraryPath(config.SteamId);
+        return Path.Combine(steamLibraryPath, config.Path);
     }
 }

--- a/src/Core/Games/Steam.cs
+++ b/src/Core/Games/Steam.cs
@@ -1,6 +1,8 @@
-﻿using Gameloop.Vdf;
+﻿using Core.Utils;
+using Gameloop.Vdf;
 using Gameloop.Vdf.JsonConverter;
 using Microsoft.Win32;
+using System.IO;
 
 namespace Core.Games;
 
@@ -11,21 +13,32 @@ public static class Steam
         @"HKEY_LOCAL_MACHINE\SOFTWARE\Valve\Steam"
     };
 
-    public static string? MainInstallationDirectory()
+    public static string MainInstallationPath()
     {
-        return RegistryPaths.Select(registryPath =>
-            Registry.GetValue(registryPath, "InstallPath", null) as string
-        ).FirstOrDefault(path => path != null && Directory.Exists(path));
+        try {
+            return RegistryPaths
+                .SelectNotNull(registryPath =>
+                    Registry.GetValue(registryPath, "InstallPath", null) as string
+                ).Single(path => Directory.Exists(path));
+        }
+        catch (Exception e)
+        {
+            throw new Exception("Cannot find Steam installation path", e);
+        }
     }
 
-    public static string? AppLibraryPath(string appId)
+    public static string AppLibraryPath(string appId)
     {
-        var steamDir = MainInstallationDirectory();
-        if (steamDir == null)
-            return null;
+        var steamDir = MainInstallationPath();
         var libraryFoldersPath = Path.Combine(steamDir, "steamapps", "libraryfolders.vdf");
-        var libraryFolders = ReadLibraryFolders(libraryFoldersPath);
-        return libraryFolders.SingleOrDefault(lf => lf.Apps.ContainsKey(appId))?.Path;
+        var gameLibraryFolders = ReadLibraryFolders(libraryFoldersPath)
+            .Where(lf => lf.Apps.ContainsKey(appId));
+        return gameLibraryFolders.Count() switch
+        {
+            0 => throw new Exception($"Cannot find app ID {appId} in any Steam library"),
+            1 => gameLibraryFolders.Single().Path,
+            var count => throw new Exception($"App ID {appId} found in {count} Steam libraries")
+        };
     }
 
     private static IEnumerable<LibraryFolder> ReadLibraryFolders(string path)
@@ -33,8 +46,8 @@ public static class Steam
         var libraryFolders = File.ReadAllText(path);
         var vdfRoot = VdfConvert.Deserialize(libraryFolders);
         return vdfRoot.ToJson().Value
-            .SelectMany(i => i)
-            .Select(i => i.ToObject<LibraryFolder>()!);
+            .SelectMany(_ => _)
+            .Select(_ => _.ToObject<LibraryFolder>()!);
     }
 
     private record LibraryFolder


### PR DESCRIPTION
It should help users with situations like #118.

Specific errors to replace generic ones like:
- `Cannot find game directory` → `Cannot find Steam installation path`
- `Cannot find game directory` → `Cannot find app ID {appId} in any Steam library`
- `Sequence contains more than one matching element` → `App ID {appId} found in {count} Steam libraries`
- `Cannot find game directory` → `The game directory does not exist`