### PR TITLE
Support extracted mods

### DIFF
--- a/src/Core/InstallationFactory.cs
+++ b/src/Core/InstallationFactory.cs
@@ -21,7 +21,9 @@ public class InstallationFactory : IInstallationFactory
     }
 
     public IInstaller ModInstaller(ModPackage modPackage) =>
-        new ModArchiveInstaller(modPackage.PackageName, modPackage.FsHash, tempDir, config, modPackage.FullPath);
+        Directory.Exists(modPackage.FullPath)
+            ? new ModDirectoryInstaller(modPackage.PackageName, modPackage.FsHash, tempDir, config, modPackage.FullPath)
+            : new ModArchiveInstaller(modPackage.PackageName, modPackage.FsHash, tempDir, config, modPackage.FullPath);
 
     public IInstaller GeneratedBootfilesInstaller() =>
         new GeneratedBootfilesInstaller(tempDir, config, game);

--- a/src/Core/ModManager.cs
+++ b/src/Core/ModManager.cs
@@ -69,7 +69,6 @@ internal class ModManager : IModManager
         return allPackageNames
             .Select(packageName => {
                 return new ModState(
-                    ModName: Path.GetFileNameWithoutExtension(packageName),
                     PackageName: packageName,
                     PackagePath: availableModPackages.TryGetValue(packageName, out var modPackage) ? modPackage.FullPath : null,
                     IsInstalled: isModInstalled.TryGetValue(packageName, out var isInstalled) ? isInstalled : false,
@@ -105,7 +104,6 @@ internal class ModManager : IModManager
         statePersistence.ReadState().Install.Mods.TryGetValue(modPackage.PackageName, out var modInstallationState);
 
         return new ModState(
-                ModName: modPackage.Name,
                 PackageName: modPackage.PackageName,
                 PackagePath: modPackage.FullPath,
                 IsEnabled: modPackage.Enabled,

--- a/src/Core/ModState.cs
+++ b/src/Core/ModState.cs
@@ -1,7 +1,6 @@
 ﻿namespace Core;
 
 public record ModState(
-    string ModName,
     string PackageName,
     string? PackagePath,
     bool? IsInstalled, // null is partial

--- a/src/Core/Mods/IModRepository.cs
+++ b/src/Core/Mods/IModRepository.cs
@@ -16,5 +16,5 @@ public record ModPackage
     string PackageName, // TODO: rename to ID
     string FullPath,
     bool Enabled,
-    int FsHash
+    int? FsHash
 );

--- a/src/Core/Mods/IModRepository.cs
+++ b/src/Core/Mods/IModRepository.cs
@@ -12,8 +12,7 @@ public interface IModRepository
 
 public record ModPackage
 (
-    string Name,
-    string PackageName, // TODO: rename to ID
+    string PackageName,
     string FullPath,
     bool Enabled,
     int? FsHash

--- a/src/Core/Mods/ModDirectoryInstaller.cs
+++ b/src/Core/Mods/ModDirectoryInstaller.cs
@@ -1,0 +1,24 @@
+﻿namespace Core.Mods;
+
+internal class ModDirectoryInstaller : BaseDirectoryInstaller
+{
+    public ModDirectoryInstaller(string packageName, int? packageFsHash, ITempDir tempDir, BaseInstaller.IConfig config, string sourcePath) :
+        base(packageName, packageFsHash, tempDir, config)
+    {
+        Source = new DirectoryInfo(sourcePath);
+    }
+
+    protected override DirectoryInfo Source
+    {
+        get;
+    }
+
+    protected override void InstallFile(RootedPath destinationPath, FileInfo fileInfo)
+    {
+        File.Copy(fileInfo.FullName, destinationPath.Full);
+    }
+
+    public override void Dispose()
+    {
+    }
+}

--- a/src/Core/Mods/ModRepository.cs
+++ b/src/Core/Mods/ModRepository.cs
@@ -5,13 +5,14 @@ public class ModRepository : IModRepository
     private const string EnabledModsDirName = "Enabled";
     private const string DisabledModsSubdir = "Disabled";
 
-    private readonly string enabledModArchivesDir;
-    private readonly string disabledModArchivesDir;
+    private readonly string enabledModsDir;
+    private readonly string disabledModsDir;
 
     internal ModRepository(string modsDir)
     {
-        enabledModArchivesDir = Path.Combine(modsDir, EnabledModsDirName);
-        disabledModArchivesDir = Path.Combine(modsDir, DisabledModsSubdir);
+        var modsDirFullPath = Path.GetFullPath(modsDir);
+        enabledModsDir = Path.Combine(modsDirFullPath, EnabledModsDirName);
+        disabledModsDir =  Path.Combine(modsDirFullPath, DisabledModsSubdir);
     }
 
     public ModPackage UploadMod(string sourceFilePath)
@@ -19,36 +20,43 @@ public class ModRepository : IModRepository
         var fileName = Path.GetFileName(sourceFilePath);
 
         var isDisabled = ListDisabledMods().Where(_ => _.PackageName == fileName).Any();
-        var destinationDirectoryPath = isDisabled ? disabledModArchivesDir : enabledModArchivesDir;
+        var destinationDirectoryPath = isDisabled ? disabledModsDir : enabledModsDir;
         var destinationFilePath = Path.Combine(destinationDirectoryPath, fileName);
 
         ExistingDirectoryOrCreate(destinationDirectoryPath);
         File.Copy(sourceFilePath, destinationFilePath, overwrite: true);
 
-        return ModPackageFrom(destinationDirectoryPath, new FileInfo(destinationFilePath));
+        return ModFilePackage(new FileInfo(destinationFilePath));
     }
 
     public string EnableMod(string packagePath)
     {
-        return MoveMod(packagePath, enabledModArchivesDir);
+        return MoveMod(packagePath, enabledModsDir);
     }
 
     public string DisableMod(string packagePath)
     {
-        return MoveMod(packagePath, disabledModArchivesDir);
+        return MoveMod(packagePath, disabledModsDir);
     }
 
-    private static string MoveMod(string packagePath, string destinationDirectoryPath)
+    private static string MoveMod(string sourcePackagePath, string destinationParentPath)
     {
-        ExistingDirectoryOrCreate(destinationDirectoryPath);
-        var destinationFilePath = Path.Combine(destinationDirectoryPath, Path.GetFileName(packagePath));
-        File.Move(packagePath, destinationFilePath);
-        return destinationFilePath;
+        ExistingDirectoryOrCreate(destinationParentPath);
+        var destinationPackagePath = Path.Combine(destinationParentPath, Path.GetFileName(sourcePackagePath));
+        if (Directory.Exists(sourcePackagePath))
+        {
+            Directory.Move(sourcePackagePath, destinationPackagePath);
+        }
+        else
+        {
+            File.Move(sourcePackagePath, destinationPackagePath);
+        }
+        return destinationPackagePath;
     }
 
-    public IReadOnlyCollection<ModPackage> ListEnabledMods() => ListMods(enabledModArchivesDir);
+    public IReadOnlyCollection<ModPackage> ListEnabledMods() => ListMods(enabledModsDir);
 
-    public IReadOnlyCollection<ModPackage> ListDisabledMods() => ListMods(disabledModArchivesDir);
+    public IReadOnlyCollection<ModPackage> ListDisabledMods() => ListMods(disabledModsDir);
 
     private IReadOnlyCollection<ModPackage> ListMods(string rootPath)
     {
@@ -62,8 +70,8 @@ public class ModRepository : IModRepository
                 AttributesToSkip = FileAttributes.Hidden | FileAttributes.System,
                 RecurseSubdirectories = false,
             };
-            return directoryInfo.GetFiles("*", options)
-                .Select(fileInfo => ModPackageFrom(rootPath, fileInfo))
+            return directoryInfo.GetFiles("*", options).Select(fileInfo => ModFilePackage(fileInfo))
+                .Concat(directoryInfo.GetDirectories("*", options).Select(fileInfo => ModDirectoryPackage(fileInfo)))
                 .ToList();
         }
         else
@@ -72,17 +80,29 @@ public class ModRepository : IModRepository
         }
     }
 
-    private static ModPackage ModPackageFrom(string rootPath, FileInfo modFileInfo)
+    private ModPackage ModFilePackage(FileInfo modFileInfo)
     {
+        return ModDirectoryPackage(modFileInfo) with
+        {
+            FsHash = FsHash(modFileInfo)
+        };
+    }
+
+    private ModPackage ModDirectoryPackage(FileSystemInfo modFileSystemInfo)
+    {
+
         return new ModPackage
         (
-            Name: Path.GetFileNameWithoutExtension(modFileInfo.Name),
-            PackageName: modFileInfo.Name,
-            FullPath: modFileInfo.FullName,
-            Enabled: Path.GetDirectoryName(rootPath) == EnabledModsDirName,
-            FsHash: FsHash(modFileInfo)
+            Name: Path.GetFileNameWithoutExtension(modFileSystemInfo.Name),
+            PackageName: modFileSystemInfo.Name,
+            FullPath: modFileSystemInfo.FullName,
+            Enabled: IsEnabled(modFileSystemInfo), 
+            FsHash: null
         );
     }
+
+    private bool IsEnabled(FileSystemInfo modFileSystemInfo) =>
+        Directory.GetParent(modFileSystemInfo.FullName)?.FullName == enabledModsDir;
 
     /// <summary>
     /// Just a very simple has function to detect if the file might have changed.

--- a/src/Core/Mods/ModRepository.cs
+++ b/src/Core/Mods/ModRepository.cs
@@ -80,26 +80,21 @@ public class ModRepository : IModRepository
         }
     }
 
-    private ModPackage ModFilePackage(FileInfo modFileInfo)
-    {
-        return ModDirectoryPackage(modFileInfo) with
-        {
-            FsHash = FsHash(modFileInfo)
-        };
-    }
+    private ModPackage ModFilePackage(FileInfo modFileInfo) =>
+        new(
+            PackageName: modFileInfo.Name,
+            FullPath: modFileInfo.FullName,
+            Enabled: IsEnabled(modFileInfo),
+            FsHash: FsHash(modFileInfo)
+        );
 
-    private ModPackage ModDirectoryPackage(FileSystemInfo modFileSystemInfo)
-    {
-
-        return new ModPackage
-        (
-            Name: Path.GetFileNameWithoutExtension(modFileSystemInfo.Name),
-            PackageName: modFileSystemInfo.Name,
-            FullPath: modFileSystemInfo.FullName,
-            Enabled: IsEnabled(modFileSystemInfo), 
+    private ModPackage ModDirectoryPackage(DirectoryInfo modDirectoryInfo) =>
+        new(
+            PackageName: $"{modDirectoryInfo.Name}{Path.DirectorySeparatorChar}",
+            FullPath: modDirectoryInfo.FullName,
+            Enabled: IsEnabled(modDirectoryInfo),
             FsHash: null
         );
-    }
 
     private bool IsEnabled(FileSystemInfo modFileSystemInfo) =>
         Directory.GetParent(modFileSystemInfo.FullName)?.FullName == enabledModsDir;

--- a/src/GUI/MainWindow.xaml
+++ b/src/GUI/MainWindow.xaml
@@ -89,7 +89,7 @@
                             <TextBlock
                                 Grid.Column="2"
                                 VerticalAlignment="Center"
-                                Text="{x:Bind Name}"
+                                Text="{x:Bind DisplayName}"
                                 ToolTipService.ToolTip="{x:Bind PackageName}"/>
                             <SymbolIcon Grid.Column="3"
                                 Visibility="{x:Bind IsOutOfDate}"

--- a/src/GUI/MainWindow.xaml.cs
+++ b/src/GUI/MainWindow.xaml.cs
@@ -66,7 +66,7 @@ public sealed partial class MainWindow : WindowEx
     private void SyncModListView()
     {
         modList.Clear();
-        foreach (var modState in modManager.FetchState().OrderBy(_ => _.ModName).ThenBy(_ => _.PackageName))
+        foreach (var modState in modManager.FetchState().OrderBy(_ => _.PackageName))
         {
             modList.Add(new ModVM(modState, modManager));
         }

--- a/src/GUI/MainWindow.xaml.cs
+++ b/src/GUI/MainWindow.xaml.cs
@@ -88,19 +88,24 @@ public sealed partial class MainWindow : WindowEx
 
     private async void ModListView_DragItemsStarting(object sender, Microsoft.UI.Xaml.Controls.DragItemsStartingEventArgs e)
     {
+        var storageItems = new List<StorageFile>();
         var filePaths = e.Items.OfType<ModVM>().SelectNotNull(_ => _.PackagePath);
-        if (!filePaths.Any())
+        foreach (var filePath in filePaths)
+        {
+            if (Directory.Exists(filePath))
+            {
+                continue;
+            }
+            var si = await StorageFile.GetFileFromPathAsync(filePath);
+            storageItems.Add(si);
+        }
+
+        if (!storageItems.Any())
         {
             e.Cancel = true;
             return;
         }
 
-        var storageItems = new List<StorageFile>();
-        foreach (var filePath in filePaths)
-        {
-            var si = await StorageFile.GetFileFromPathAsync(filePath);
-            storageItems.Add(si);
-        }
         e.Data.SetStorageItems(storageItems);
         e.Data.RequestedOperation = DataPackageOperation.Move;
     }

--- a/src/GUI/ModVM.cs
+++ b/src/GUI/ModVM.cs
@@ -22,7 +22,10 @@ internal class ModVM : INotifyPropertyChanged
         isOutOfDate = modState.IsOutOfDate;
     }
 
-    public string Name => modState.ModName;
+    public string DisplayName =>
+        Path.EndsInDirectorySeparator(modState.PackageName)
+        ? Path.TrimEndingDirectorySeparator(modState.PackageName)
+        : Path.GetFileNameWithoutExtension(modState.PackageName);
 
     public string PackageName => modState.PackageName;
 

--- a/tests/Core.Tests/AbstractFilesystemTest.cs
+++ b/tests/Core.Tests/AbstractFilesystemTest.cs
@@ -1,0 +1,41 @@
+﻿namespace Core.Tests;
+
+public abstract class AbstractFilesystemTest : IDisposable
+{
+    protected readonly DirectoryInfo testDir;
+
+    protected AbstractFilesystemTest()
+    {
+        testDir = Directory.CreateTempSubdirectory(GetType().Name);
+    }
+
+    public void Dispose()
+    {
+        testDir.Delete(recursive: true);
+    }
+
+    protected void CreateTestFiles(params string[] relativePaths)
+    {
+        foreach (var relativePath in relativePaths)
+        {
+            CreateTestFile(relativePath);
+        }
+    }
+
+    protected FileInfo CreateTestFile(string relativePath, string content = "") =>
+        CreateFile(TestPath(relativePath), content);
+
+    protected string TestPath(string relativePath) =>
+        Path.Combine(testDir.FullName, relativePath);
+
+    protected static FileInfo CreateFile(string fullPath, string content = "")
+    {
+        var parentDirFullPath = Path.GetDirectoryName(fullPath);
+        if (parentDirFullPath is not null)
+        {
+            Directory.CreateDirectory(parentDirFullPath);
+        }
+        File.WriteAllText(fullPath, content);
+        return new FileInfo(fullPath);
+    }
+}

--- a/tests/Core.Tests/ModManagerTest.cs
+++ b/tests/Core.Tests/ModManagerTest.cs
@@ -527,7 +527,7 @@ public class ModManagerTest : AbstractFilesystemTest
         var archivePath = $@"{modsDir.FullName}\{modName}.zip";
         // TODO LibArchive.Net does not support compression yet
         ZipFile.CreateFromDirectory(modContentsDir, archivePath);
-        return new ModPackage(modName, $"{packagePrefix}{fsHash}", archivePath, true, fsHash);
+        return new ModPackage($"{packagePrefix}{fsHash}", archivePath, true, fsHash);
     }
 
     private FileInfo CreateGameFile(string relativePath, string content = "") =>

--- a/tests/Core.Tests/ModManagerTest.cs
+++ b/tests/Core.Tests/ModManagerTest.cs
@@ -9,7 +9,7 @@ using System;
 using System.Collections.Immutable;
 using System.IO.Compression;
 
-public class ModManagerTest : IDisposable
+public class ModManagerTest : AbstractFilesystemTest
 {
     #region Initialisation
 
@@ -18,7 +18,6 @@ public class ModManagerTest : IDisposable
 
     private static readonly TimeSpan TimeTolerance = TimeSpan.FromMilliseconds(100);
 
-    private readonly DirectoryInfo testDir;
     private readonly DirectoryInfo gameDir;
     private readonly DirectoryInfo modsDir;
 
@@ -32,9 +31,8 @@ public class ModManagerTest : IDisposable
 
     private readonly ModManager modManager;
 
-    public ModManagerTest()
+    public ModManagerTest() : base()
     {
-        testDir = Directory.CreateTempSubdirectory(GetType().Name);
         gameDir = testDir.CreateSubdirectory("Game");
         modsDir = testDir.CreateSubdirectory("Packages");
 
@@ -60,11 +58,6 @@ public class ModManagerTest : IDisposable
             tempDir);
 
         gameMock.Setup(_ => _.InstallationDirectory).Returns(gameDir.FullName);
-    }
-
-    public void Dispose()
-    {
-        testDir.Delete(recursive: true);
     }
 
     #endregion
@@ -539,17 +532,6 @@ public class ModManagerTest : IDisposable
 
     private FileInfo CreateGameFile(string relativePath, string content = "") =>
         CreateFile(GamePath(relativePath), content);
-
-    private FileInfo CreateFile(string fullPath, string content = "")
-    {
-        var parentDirFullPath = Path.GetDirectoryName(fullPath);
-        if (parentDirFullPath is not null)
-        {
-            Directory.CreateDirectory(parentDirFullPath);
-        }
-        File.WriteAllText(fullPath, content);
-        return new FileInfo(fullPath);
-    }
 
     // This can be removed once we introduce backup strategies
     private string BackupName(string relativePath) =>

--- a/tests/Core.Tests/Mods/ModRepositoryTest.cs
+++ b/tests/Core.Tests/Mods/ModRepositoryTest.cs
@@ -26,15 +26,15 @@ public class ModRepositoryTest : AbstractFilesystemTest
 
         Assert.Equivalent(
             new ModPackage[] {
-                new("File1", "File1.Ext", Path.Combine(testDir.FullName, @"Enabled\File1.Ext"), true, NotChecked),
-                new("File2", "File2.Ext", Path.Combine(testDir.FullName, @"Enabled\File2.Ext"), true, NotChecked)
+                new("File1.Ext", Path.Combine(testDir.FullName, @"Enabled\File1.Ext"), true, NotChecked),
+                new("File2.Ext", Path.Combine(testDir.FullName, @"Enabled\File2.Ext"), true, NotChecked)
             },
             modRepository.ListEnabledMods().Select(_ => _ with {  FsHash = NotChecked })
         );
         Assert.Equivalent(
             new ModPackage[] {
-                        new("File3", "File3.Ext", Path.Combine(testDir.FullName, @"Disabled\File3.Ext"), false, NotChecked),
-                        new("File4", "File4.Ext", Path.Combine(testDir.FullName, @"Disabled\File4.Ext"), false, NotChecked)
+                new("File3.Ext", Path.Combine(testDir.FullName, @"Disabled\File3.Ext"), false, NotChecked),
+                new("File4.Ext", Path.Combine(testDir.FullName, @"Disabled\File4.Ext"), false, NotChecked)
             },
             modRepository.ListDisabledMods().Select(_ => _ with { FsHash = NotChecked })
         );
@@ -52,15 +52,15 @@ public class ModRepositoryTest : AbstractFilesystemTest
 
         Assert.Equivalent(
             new ModPackage[] {
-                new("Dir1", "Dir1", Path.Combine(testDir.FullName, @"Enabled\Dir1"), true, null),
-                new("Dir2", "Dir2", Path.Combine(testDir.FullName, @"Enabled\Dir2"), true, null)
+                new(@"Dir1\", Path.Combine(testDir.FullName, @"Enabled\Dir1"), true, null),
+                new(@"Dir2\", Path.Combine(testDir.FullName, @"Enabled\Dir2"), true, null)
             },
             modRepository.ListEnabledMods()
         );
         Assert.Equivalent(
             new ModPackage[] {
-                new("Dir3", "Dir3", Path.Combine(testDir.FullName, @"Disabled\Dir3"), false, null),
-                new("Dir4", "Dir4", Path.Combine(testDir.FullName, @"Disabled\Dir4"), false, null)
+                new(@"Dir3\", Path.Combine(testDir.FullName, @"Disabled\Dir3"), false, null),
+                new(@"Dir4\", Path.Combine(testDir.FullName, @"Disabled\Dir4"), false, null)
             },
             modRepository.ListDisabledMods()
         );

--- a/tests/Core.Tests/Mods/ModRepositoryTest.cs
+++ b/tests/Core.Tests/Mods/ModRepositoryTest.cs
@@ -1,0 +1,116 @@
+using Core.Mods;
+using Moq;
+
+namespace Core.Tests.Mods;
+
+public class ModRepositoryTest : AbstractFilesystemTest
+{
+    private const int NotChecked = 42;
+
+    private readonly ModRepository modRepository;
+
+    public ModRepositoryTest() : base()
+    {
+        modRepository = new(testDir.FullName);
+    }
+
+    [Fact]
+    public void ListMods_FindsFiles()
+    {
+        CreateTestFiles(
+            @"Enabled\File1.Ext",
+            @"Enabled\File2.Ext",
+            @"Disabled\File3.Ext",
+            @"Disabled\File4.Ext"
+        );
+
+        Assert.Equivalent(
+            new ModPackage[] {
+                new("File1", "File1.Ext", Path.Combine(testDir.FullName, @"Enabled\File1.Ext"), true, NotChecked),
+                new("File2", "File2.Ext", Path.Combine(testDir.FullName, @"Enabled\File2.Ext"), true, NotChecked)
+            },
+            modRepository.ListEnabledMods().Select(_ => _ with {  FsHash = NotChecked })
+        );
+        Assert.Equivalent(
+            new ModPackage[] {
+                        new("File3", "File3.Ext", Path.Combine(testDir.FullName, @"Disabled\File3.Ext"), false, NotChecked),
+                        new("File4", "File4.Ext", Path.Combine(testDir.FullName, @"Disabled\File4.Ext"), false, NotChecked)
+            },
+            modRepository.ListDisabledMods().Select(_ => _ with { FsHash = NotChecked })
+        );
+    }
+
+    [Fact]
+    public void ListMods_FindsDirectories()
+    {
+        CreateTestFiles(
+            @"Enabled\Dir1\Content",
+            @"Enabled\Dir2\SubDir\Content",
+            @"Disabled\Dir3\Content",
+            @"Disabled\Dir4\SubDir\Content"
+        );
+
+        Assert.Equivalent(
+            new ModPackage[] {
+                new("Dir1", "Dir1", Path.Combine(testDir.FullName, @"Enabled\Dir1"), true, null),
+                new("Dir2", "Dir2", Path.Combine(testDir.FullName, @"Enabled\Dir2"), true, null)
+            },
+            modRepository.ListEnabledMods()
+        );
+        Assert.Equivalent(
+            new ModPackage[] {
+                new("Dir3", "Dir3", Path.Combine(testDir.FullName, @"Disabled\Dir3"), false, null),
+                new("Dir4", "Dir4", Path.Combine(testDir.FullName, @"Disabled\Dir4"), false, null)
+            },
+            modRepository.ListDisabledMods()
+        );
+    }
+
+    [Fact]
+    public void EnableMod_MovesFiles()
+    {
+        CreateTestFiles(
+            @"Disabled\File.Ext"
+        );
+
+        modRepository.EnableMod(TestPath(@"Disabled\File.Ext"));
+
+        Assert.True(File.Exists(TestPath(@"Enabled\File.Ext")));
+    }
+
+    [Fact]
+    public void EnableMod_MovesDirectories()
+    {
+        CreateTestFiles(
+            @"Disabled\Dir\Contents"
+        );
+
+        modRepository.EnableMod(TestPath(@"Disabled\Dir"));
+
+        Assert.True(Directory.Exists(TestPath(@"Enabled\Dir")));
+    }
+
+    [Fact]
+    public void DisableMod_MovesFiles()
+    {
+        CreateTestFiles(
+            @"Enabled\File.Ext"
+        );
+
+        modRepository.DisableMod(TestPath(@"Enabled\File.Ext"));
+
+        Assert.True(File.Exists(TestPath(@"Disabled\File.Ext")));
+    }
+
+    [Fact]
+    public void DisableMod_MovesDirectories()
+    {
+        CreateTestFiles(
+            @"Enabled\Dir\Contents"
+        );
+
+        modRepository.DisableMod(TestPath(@"Enabled\Dir"));
+
+        Assert.True(Directory.Exists(TestPath(@"Disabled\Dir")));
+    }
+}


### PR DESCRIPTION
Closes #100.

Allows mods to be provided as extracted directory.

Notes:
- Directories are always considered out of date (this feature should be used only for mod development).
- Drag and drop does not work, as it is meant to be used by power users only (modders).
- Package name for directories ends with a directory separator.