### PR TITLE
Switch to Fluent Assertions

### DIFF
--- a/tests/Core.Tests/Backup/MoveFileBackupStrategyTest.cs
+++ b/tests/Core.Tests/Backup/MoveFileBackupStrategyTest.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO.Abstractions.TestingHelpers;
 using Core.Backup;
+using FluentAssertions;
 
 namespace Core.Tests.Backup;
 
@@ -24,8 +25,8 @@ public class MoveFileBackupStrategyTest
 
         sbs.PerformBackup(OriginalFile);
 
-        Assert.False(fs.FileExists(OriginalFile));
-        Assert.Equal(OriginalContents, fs.File.ReadAllText(BackupFile));
+        fs.FileExists(OriginalFile).Should().BeFalse();
+        fs.File.ReadAllText(BackupFile).Should().Be(OriginalContents);
     }
 
     [Fact]
@@ -37,7 +38,7 @@ public class MoveFileBackupStrategyTest
 
         sbs.PerformBackup(OriginalFile);
 
-        Assert.False(fs.FileExists(BackupFile));
+        fs.FileExists(BackupFile).Should().BeFalse();
     }
 
     [Fact]
@@ -54,8 +55,8 @@ public class MoveFileBackupStrategyTest
 
         sbs.PerformBackup(OriginalFile);
 
-        Assert.False(fs.FileExists(OriginalFile));
-        Assert.Equal(oldBackupContents, fs.File.ReadAllText(BackupFile));
+        fs.FileExists(OriginalFile).Should().BeFalse();
+        fs.File.ReadAllText(BackupFile).Should().Be(oldBackupContents);
     }
 
     [Fact]
@@ -70,8 +71,8 @@ public class MoveFileBackupStrategyTest
 
         sbs.RestoreBackup(OriginalFile);
 
-        Assert.Equal(OriginalContents, fs.File.ReadAllText(OriginalFile));
-        Assert.False(fs.FileExists(BackupFile));
+        fs.File.ReadAllText(OriginalFile).Should().Be(OriginalContents);
+        fs.FileExists(BackupFile).Should().BeFalse();
     }
 
     [Fact]
@@ -86,7 +87,7 @@ public class MoveFileBackupStrategyTest
 
         sbs.RestoreBackup(OriginalFile);
 
-        Assert.True(fs.FileExists(OriginalFile));
+        fs.FileExists(OriginalFile).Should().BeTrue();
     }
 
     [Fact]
@@ -100,10 +101,10 @@ public class MoveFileBackupStrategyTest
 
         var sbs = new MoveFileBackupStrategy(fs, GenerateBackupFilePath);
 
-        Assert.Throws<IOException>(() => sbs.RestoreBackup(OriginalFile));
+        sbs.Invoking(_ =>  _.RestoreBackup(OriginalFile)).Should().Throw<IOException>();
 
-        Assert.NotEqual(OriginalContents, fs.File.ReadAllText(OriginalFile));
-        Assert.True(fs.FileExists(BackupFile));
+        fs.File.ReadAllText(OriginalFile).Should().NotBe(OriginalContents);
+        fs.FileExists(BackupFile).Should().BeTrue();
     }
 
     [Fact]
@@ -118,8 +119,8 @@ public class MoveFileBackupStrategyTest
 
         sbs.DeleteBackup(OriginalFile);
 
-        Assert.False(fs.FileExists(OriginalFile));
-        Assert.False(fs.FileExists(BackupFile));
+        fs.FileExists(OriginalFile).Should().BeFalse();
+        fs.FileExists(BackupFile).Should().BeFalse();
 
         sbs.DeleteBackup(OriginalFile); // Check that it does not error
     }

--- a/tests/Core.Tests/Core.Tests.csproj
+++ b/tests/Core.Tests/Core.Tests.csproj
@@ -13,21 +13,25 @@
 		<ProjectReference Include="..\..\src\Core\Core.csproj" />
 	</ItemGroup>
 
-	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-		<PackageReference Include="xunit" Version="2.8.0" />
-    <PackageReference Include="xunit.categories" Version="2.0.6" />
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="xunit" Version="2.9.0" />
+    <PackageReference Include="xunit.categories" Version="2.0.8" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
-    <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="21.0.2" />
+    <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="21.0.26" />
 
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-			<PrivateAssets>all</PrivateAssets>
-		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="6.0.2">
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-			<PrivateAssets>all</PrivateAssets>
-		</PackageReference>
-	</ItemGroup>
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="FluentAssertions.Analyzers" Version="0.33.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 </Project>

--- a/tests/Core.Tests/Core.Tests.csproj
+++ b/tests/Core.Tests/Core.Tests.csproj
@@ -15,9 +15,12 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-		<PackageReference Include="Moq" Version="4.20.70" />
 		<PackageReference Include="xunit" Version="2.8.0" />
     <PackageReference Include="xunit.categories" Version="2.0.6" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="21.0.2" />
+
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
@@ -26,6 +29,5 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="21.0.2" />
 	</ItemGroup>
 </Project>

--- a/tests/Core.Tests/Mods/ContainedDirsRootFinderTest.cs
+++ b/tests/Core.Tests/Mods/ContainedDirsRootFinderTest.cs
@@ -1,4 +1,5 @@
 ﻿using Core.Mods;
+using FluentAssertions;
 
 namespace Core.Tests.Mods;
 
@@ -11,84 +12,72 @@ public class ContainedDirsRootFinderTest
     [Fact]
     public void FromDirectoryList_FindsDirsAtRoot()
     {
-        Assert.Equal(
-            [
-                "",
-            ],
-            rootFinder.FromDirectoryList(
+        rootFinder.FromDirectoryList(
             [
                 Path.Combine("R1"),
-            ]).Roots);
+            ]).Roots.Should().BeEquivalentTo([
+                "",
+            ]);
     }
 
     [Fact]
     public void FromDirectoryList_FindsDirsWhenNamePrefixOfOtherDirs()
     {
-        Assert.Equal(
-            [
-                "D1",
-                "D11"
-            ],
-            rootFinder.FromDirectoryList(
+        rootFinder.FromDirectoryList(
             [
                 Path.Combine("D1", "R1"),
                 Path.Combine("D11", "R1")
-            ]).Roots);
+            ]).Roots.Should().BeEquivalentTo([
+                "D1",
+                "D11"
+            ]);
     }
 
     [Fact]
     public void FromDirectoryList_IgnoresNestedRoots()
     {
-        Assert.Equal(
-            [
-                "D1"
-            ],
-            rootFinder.FromDirectoryList(
+        rootFinder.FromDirectoryList(
             [
                 Path.Combine("D1", "D2", "R1"),
                 Path.Combine("D1", "R1"),
                 Path.Combine("D1", "D3", "R1")
-            ]).Roots);
+            ]).Roots.Should().BeEquivalentTo([
+                "D1"
+            ]);
 
         // Empty path is a special case
-        Assert.Equal(
-            [
-                ""
-            ],
-            rootFinder.FromDirectoryList(
+        rootFinder.FromDirectoryList(
             [
                 Path.Combine("D1", "R1"),
                 Path.Combine("R1"),
                 Path.Combine("D2", "R2")
-            ]).Roots);
+            ]).Roots.Should().BeEquivalentTo([
+                ""
+            ]);
     }
 
     [Fact]
     public void FromDirectoryList_IsCaseInsensitive()
     {
-        Assert.Equal(
-            [
-                "d1",
-            ],
-            rootFinder.FromDirectoryList(
+        rootFinder.FromDirectoryList(
             [
                 Path.Combine("d1", "r1"),
-            ]).Roots);
+            ]).Roots.Should().BeEquivalentTo([
+                "d1",
+            ]);
     }
 
     [Fact]
     public void FromDirectoryList_FindsDirsInSubDirs()
     {
-        Assert.Equal(
-            [
-                "D1",
-                Path.Combine("D2", "D3")
-            ],
-            rootFinder.FromDirectoryList(
+        rootFinder.FromDirectoryList(
             [
                 Path.Combine("D1", "R1"),
                 Path.Combine("D2", "D3", "R2"),
                 Path.Combine("D4")
-            ]).Roots);
+            ]).Roots.Should().BeEquivalentTo([
+                "D1",
+                Path.Combine("D2", "D3")
+            ]);
     }
 }

--- a/tests/Core.Tests/Mods/ModRepositoryIntegrationTest.cs
+++ b/tests/Core.Tests/Mods/ModRepositoryIntegrationTest.cs
@@ -1,4 +1,5 @@
 using Core.Mods;
+using FluentAssertions;
 
 namespace Core.Tests.Mods;
 
@@ -23,20 +24,17 @@ public class ModRepositoryIntegrationTest : AbstractFilesystemTest
             @"Disabled\File4.Ext"
         );
 
-        Assert.Equivalent(
-            new ModPackage[] {
+        modRepository.ListEnabledMods().Select(_ => _ with { FsHash = NotChecked })
+            .Should().BeEquivalentTo(new ModPackage[] {
                 new("File1.Ext", Path.Combine(testDir.FullName, @"Enabled\File1.Ext"), true, NotChecked),
                 new("File2.Ext", Path.Combine(testDir.FullName, @"Enabled\File2.Ext"), true, NotChecked)
-            },
-            modRepository.ListEnabledMods().Select(_ => _ with { FsHash = NotChecked })
-        );
-        Assert.Equivalent(
-            new ModPackage[] {
+            });
+
+        modRepository.ListDisabledMods().Select(_ => _ with { FsHash = NotChecked })
+            .Should().BeEquivalentTo(new ModPackage[] {
                 new("File3.Ext", Path.Combine(testDir.FullName, @"Disabled\File3.Ext"), false, NotChecked),
                 new("File4.Ext", Path.Combine(testDir.FullName, @"Disabled\File4.Ext"), false, NotChecked)
-            },
-            modRepository.ListDisabledMods().Select(_ => _ with { FsHash = NotChecked })
-        );
+            });
     }
 
     [Fact]
@@ -49,20 +47,16 @@ public class ModRepositoryIntegrationTest : AbstractFilesystemTest
             @"Disabled\Dir4\SubDir\Content"
         );
 
-        Assert.Equivalent(
-            new ModPackage[] {
+        modRepository.ListEnabledMods()
+            .Should().BeEquivalentTo(new ModPackage[] {
                 new(@"Dir1\", Path.Combine(testDir.FullName, @"Enabled\Dir1"), true, null),
                 new(@"Dir2\", Path.Combine(testDir.FullName, @"Enabled\Dir2"), true, null)
-            },
-            modRepository.ListEnabledMods()
-        );
-        Assert.Equivalent(
-            new ModPackage[] {
+            });
+        modRepository.ListDisabledMods()
+            .Should().BeEquivalentTo(new ModPackage[] {
                 new(@"Dir3\", Path.Combine(testDir.FullName, @"Disabled\Dir3"), false, null),
                 new(@"Dir4\", Path.Combine(testDir.FullName, @"Disabled\Dir4"), false, null)
-            },
-            modRepository.ListDisabledMods()
-        );
+            });
     }
 
     [Fact]
@@ -74,7 +68,7 @@ public class ModRepositoryIntegrationTest : AbstractFilesystemTest
 
         modRepository.EnableMod(TestPath(@"Disabled\File.Ext"));
 
-        Assert.True(File.Exists(TestPath(@"Enabled\File.Ext")));
+        File.Exists(TestPath(@"Enabled\File.Ext")).Should().BeTrue();
     }
 
     [Fact]
@@ -86,7 +80,7 @@ public class ModRepositoryIntegrationTest : AbstractFilesystemTest
 
         modRepository.EnableMod(TestPath(@"Disabled\Dir"));
 
-        Assert.True(Directory.Exists(TestPath(@"Enabled\Dir")));
+        Directory.Exists(TestPath(@"Enabled\Dir")).Should().BeTrue();
     }
 
     [Fact]
@@ -98,7 +92,7 @@ public class ModRepositoryIntegrationTest : AbstractFilesystemTest
 
         modRepository.DisableMod(TestPath(@"Enabled\File.Ext"));
 
-        Assert.True(File.Exists(TestPath(@"Disabled\File.Ext")));
+        File.Exists(TestPath(@"Disabled\File.Ext")).Should().BeTrue();
     }
 
     [Fact]
@@ -110,6 +104,6 @@ public class ModRepositoryIntegrationTest : AbstractFilesystemTest
 
         modRepository.DisableMod(TestPath(@"Enabled\Dir"));
 
-        Assert.True(Directory.Exists(TestPath(@"Disabled\Dir")));
+        Directory.Exists(TestPath(@"Disabled\Dir")).Should().BeTrue();
     }
 }

--- a/tests/Core.Tests/Mods/PostProcessorTest.cs
+++ b/tests/Core.Tests/Mods/PostProcessorTest.cs
@@ -1,4 +1,5 @@
 using Core.Mods;
+using FluentAssertions;
 
 namespace Core.Tests.Mods;
 
@@ -8,60 +9,48 @@ public class PostProcessorTest
     [Fact]
     public void DedupeRecordBlocks_ConsidersOnlyFirstLine()
     {
-        Assert.Equal(new[]
-        {
-            @"RECORDGROUP foo
-                last"
-        },
-        PostProcessor.DedupeRecordBlocks(new[]
-        {
+        PostProcessor.DedupeRecordBlocks([
             @"RECORDGROUP foo
                 first",
             @"RECORDGROUP foo
                 last"
-        }));
+        ]).Should().BeEquivalentTo([
+            @"RECORDGROUP foo
+                last"
+        ]);
     }
 
     [Fact]
     public void DedupeRecordBlocks_IgnoresRedundantWhitespaces()
     {
-        Assert.Equal(new[]
-        {
-            "RECORD foo\tbar"
-        },
-        PostProcessor.DedupeRecordBlocks(new[]
-        {
+        PostProcessor.DedupeRecordBlocks([
             "  RECORD foo\vbar ",
             "RECORD foo\tbar"
-        }));
+        ]).Should().BeEquivalentTo([
+            "RECORD foo\tbar"
+        ]);
     }
 
     [Fact]
     public void DedupeRecordBlocks_WorksForEmptyLines()
     {
-        Assert.Equal(new[]
-        {
+        PostProcessor.DedupeRecordBlocks([
+            "",
+            "",
+        ]).Should().BeEquivalentTo([
             ""
-        },
-        PostProcessor.DedupeRecordBlocks(new[]
-        {
-            "",
-            "",
-        }));
+        ]);
     }
 
     [Fact]
     public void DedupeRecordBlocks_AssumesCommentsAlreadyRemoved()
     {
-        Assert.Equal(new[]
-        {
+        PostProcessor.DedupeRecordBlocks([
             @"RECORD foo bar # first",
             @"RECORD foo bar # last"
-        },
-        PostProcessor.DedupeRecordBlocks(new[]
-        {
+        ]).Should().BeEquivalentTo([
             @"RECORD foo bar # first",
             @"RECORD foo bar # last"
-        }));
+        ]);
     }
 }

--- a/tests/Core.Tests/Mods/ProcessingCallbacksTest.cs
+++ b/tests/Core.Tests/Mods/ProcessingCallbacksTest.cs
@@ -1,4 +1,5 @@
 ﻿using Core.Mods;
+using FluentAssertions;
 
 namespace Core.Tests.Mods;
 
@@ -12,8 +13,8 @@ public class ProcessingCallbacksTest
     {
         var callbacks = new ProcessingCallbacks<int>();
 
-        Assert.NotNull(callbacks.Accept);
-        Assert.True(callbacks.Accept(SomeValue));
+        callbacks.Accept.Should().NotBeNull();
+        callbacks.Accept(SomeValue).Should().BeTrue();
     }
 
     [Fact]
@@ -45,7 +46,7 @@ public class ProcessingCallbacksTest
         var ma1 = new Mock<Action<int>>();
         var ma2 = new Mock<Action<int>>();
 
-        Assert.NotNull(callbacks.Before);
+        callbacks.Before.Should().NotBeNull();
 
         callbacks
             .AndBefore(ma1.Object)
@@ -63,7 +64,7 @@ public class ProcessingCallbacksTest
         var ma1 = new Mock<Action<int>>();
         var ma2 = new Mock<Action<int>>();
 
-        Assert.NotNull(callbacks.After);
+        callbacks.After.Should().NotBeNull();
 
         callbacks
             .AndAfter(ma1.Object)

--- a/tests/Core.Tests/Utils/StringExtensionsTest.cs
+++ b/tests/Core.Tests/Utils/StringExtensionsTest.cs
@@ -1,3 +1,4 @@
+using FluentAssertions;
 using static Core.Utils.StringExtensions;
 
 namespace Core.Tests.Utils;
@@ -8,14 +9,14 @@ public class PostProcessorTest
     [Fact]
     public void NormalizeWhitespaces_ReplacesWithSpaces()
     {
-        Assert.Equal("", "".NormalizeWhitespaces());
-        Assert.Equal("foo bar", "foo bar".NormalizeWhitespaces());
-        Assert.Equal("foo bar", "foo\r\v\nbar".NormalizeWhitespaces());
+        "".NormalizeWhitespaces().Should().BeEmpty();
+        "foo bar".NormalizeWhitespaces().Should().Be("foo bar");
+        "foo\r\v\nbar".NormalizeWhitespaces().Should().Be("foo bar");
     }
 
     [Fact]
     public void NormalizeWhitespaces_TrimsInput()
     {
-        Assert.Equal("foo", " foo\f".NormalizeWhitespaces());
+        " foo\f".NormalizeWhitespaces().Should().Be("foo");
     }
 }


### PR DESCRIPTION
[Fluent Assertions](https://fluentassertions.com/)...
- provides better extensibility
- allows equivalence to cascade through nested types (e.g. dict of records with a collection field)
- have reader-friendly style (XUnit assertions invert expected and actual, like al other frameworks with the same style)
- have extensible and more powerful assertions (e.g. `DateTime` range)