### PR TITLE
Fix ensure creation time in the past

### DIFF
--- a/src/Core/ModInstaller.cs
+++ b/src/Core/ModInstaller.cs
@@ -206,7 +206,7 @@ public class ModInstaller : IModInstaller
                 backupStrategy.PerformBackup(gamePath.Full);
                 installedFiles.Add(gamePath.Relative);
             },
-            After = gamePath => EnsureNotCreatedAfter(DateTime.UtcNow)
+            After = EnsureNotCreatedAfter(DateTime.UtcNow)
         };
 
         // Increase by one in case bootfiles are needed and another one to show that something is happening


### PR DESCRIPTION
The logic to ensure that mods files are in the past does not work. The commit that introduced the bug also changed the compression library to one that doesn't set creation time, so tests never failed.
- Compressed mods are always created with the current time by libarchive
- Uncompressed mods are copied, so created with the current time
- Generated bootfiles are moved, maintaining the original creation time

Not sure how to verify the fix with the current automation tests, since in the current implementation the bug can only surface for generated bootfiles 😞 It will have to be done after some large refactoring.

The fix was tested by temporarily changing `ModDirectoryInstaller.InstallFile` to use `File.Move` instead of `File.Copy`.
