### PR TITLE
Fix GUI build

### DIFF
--- a/src/GUI/GUI.csproj
+++ b/src/GUI/GUI.csproj
@@ -15,6 +15,8 @@
     <UseWinUI>true</UseWinUI>
     <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
     <ApplicationIcon>..\Shared\AMS2CM.ico</ApplicationIcon>
+    <!-- https://learn.microsoft.com/en-us/windows/apps/windows-app-sdk/release-notes-archive/experimental-channel-1.2#other-limitations-and-known-issues -->
+    <EnableMsixTooling>true</EnableMsixTooling>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Closes #135.

Applied fix from Windows App SDK 1.2 [release notes](https://learn.microsoft.com/en-us/windows/apps/windows-app-sdk/release-notes-archive/experimental-channel-1.2#other-limitations-and-known-issues).
