### PR TITLE
Convert vehicles to new mod format on install

### DIFF
--- a/src/Core/ModInstaller.cs
+++ b/src/Core/ModInstaller.cs
@@ -233,8 +233,12 @@ public class ModInstaller : IModInstaller
         return new BootfilesMod(installationFactory.ModInstaller(bootfilesPackage));
     }
 
-    private class BootfilesMod : IInstaller
+    internal class BootfilesMod : IInstaller
     {
+        internal const string VehicleListRelativeDir = "vehicles";
+        internal static readonly string TrackListRelativeDir = Path.Combine("tracks", "_data");
+        internal static readonly string DrivelineRelativeDir = Path.Combine("vehicles", "physics", "driveline");
+
         private readonly IInstaller inner;
         private bool postProcessingDone;
 
@@ -264,11 +268,11 @@ public class ModInstaller : IModInstaller
         public void PostProcessing(string dstPath, IReadOnlyList<ConfigEntries> modConfigs, IEventHandler eventHandler)
         {
             eventHandler.PostProcessingVehicles();
-            PostProcessor.AppendCrdFileEntries(dstPath, modConfigs.SelectMany(c => c.CrdFileEntries));
+            PostProcessor.AppendCrdFileEntries(new RootedPath(dstPath, VehicleListRelativeDir), modConfigs.SelectMany(c => c.CrdFileEntries));
             eventHandler.PostProcessingTracks();
-            PostProcessor.AppendTrdFileEntries(dstPath, modConfigs.SelectMany(c => c.TrdFileEntries));
+            PostProcessor.AppendTrdFileEntries(new RootedPath(dstPath, TrackListRelativeDir), modConfigs.SelectMany(c => c.TrdFileEntries));
             eventHandler.PostProcessingDrivelines();
-            PostProcessor.AppendDrivelineRecords(dstPath, modConfigs.SelectMany(c => c.DrivelineRecords));
+            PostProcessor.AppendDrivelineRecords(new RootedPath(dstPath, DrivelineRelativeDir), modConfigs.SelectMany(c => c.DrivelineRecords));
             postProcessingDone = true;
         }
     }

--- a/src/Core/Mods/RootedPath.cs
+++ b/src/Core/Mods/RootedPath.cs
@@ -2,12 +2,17 @@
 
 public class RootedPath
 {
+    public string Root { get; }
     public string Relative { get; }
     public string Full { get; }
 
     public RootedPath(string rootPath, string relativePath)
     {
+        Root = rootPath;
         Relative = relativePath;
         Full = Path.Combine(rootPath, relativePath);
     }
+
+    public RootedPath SubPath(string subPath) =>
+        new RootedPath(Root, Path.Combine(Relative, subPath));
 }

--- a/tests/Core.Tests/API/ModManagerIntegrationTest.cs
+++ b/tests/Core.Tests/API/ModManagerIntegrationTest.cs
@@ -17,6 +17,10 @@ public class ModManagerIntegrationTest : AbstractFilesystemTest
     private const string DirAtRoot = "DirAtRoot";
     private const string FileExcludedFromInstall = "Excluded";
 
+    private static readonly string VehicleListRelativePath = Path.Combine(ModInstaller.BootfilesMod.VehicleListRelativeDir, PostProcessor.VehicleListFileName);
+    private static readonly string TrackListRelativePath = Path.Combine(ModInstaller.BootfilesMod.TrackListRelativeDir, PostProcessor.TrackListFileName);
+    private static readonly string DrivelineRelativePath = Path.Combine(ModInstaller.BootfilesMod.DrivelineRelativeDir, PostProcessor.DrivelineFileName);
+
     // Randomness ensures that at least some test runs will fail if it's used
     private static readonly DateTime? ValueNotUsed = Random.Shared.Next() > 0 ? DateTime.MaxValue : DateTime.MinValue;
 
@@ -456,8 +460,8 @@ public class ModManagerIntegrationTest : AbstractFilesystemTest
         modManager.InstallEnabledMods(eventHandlerMock.Object);
 
         persistedState.Should().HaveInstalled(["Package100", "__bootfiles900"]);
-        File.ReadAllText(GamePath(PostProcessor.VehicleListRelativePath)).Should().Contain("Vehicle.crd");
-        File.ReadAllText(GamePath(PostProcessor.DrivelineRelativePath)).Should().Contain(drivelineRecord);
+        File.ReadAllText(GamePath(VehicleListRelativePath)).Should().Contain("Vehicle.crd");
+        File.ReadAllText(GamePath(DrivelineRelativePath)).Should().Contain(drivelineRecord);
     }
 
     [Fact]
@@ -466,7 +470,7 @@ public class ModManagerIntegrationTest : AbstractFilesystemTest
         modRepositoryMock.Setup(_ => _.ListEnabledMods()).Returns([
             CreateModArchive(100, [
                 Path.Combine(DirAtRoot, "Vehicle.crd"),
-                BaseInstaller.GameSupportedModDirectory
+                Path.Combine(BaseInstaller.GameSupportedModDirectory, "Anything")
             ]),
             CreateCustomBootfiles(900),
         ]);
@@ -487,8 +491,7 @@ public class ModManagerIntegrationTest : AbstractFilesystemTest
         modManager.InstallEnabledMods(eventHandlerMock.Object);
 
         persistedState.Should().HaveInstalled(["Package100", "__bootfiles900"]);
-        File.ReadAllText(GamePath(PostProcessor.TrackListRelativePath)).Should().Contain("Track.trd");
-
+        File.ReadAllText(GamePath(TrackListRelativePath)).Should().Contain("Track.trd");
     }
 
     [Fact]
@@ -534,12 +537,12 @@ public class ModManagerIntegrationTest : AbstractFilesystemTest
     private ModPackage CreateCustomBootfiles(int fsHash) =>
         CreateModPackage(BootfilesManager.BootfilesPrefix, fsHash, [
                 Path.Combine(DirAtRoot, "OrTheyWontBeInstalled"),
-            PostProcessor.VehicleListRelativePath,
-            PostProcessor.TrackListRelativePath,
-            PostProcessor.DrivelineRelativePath,
+            VehicleListRelativePath,
+            TrackListRelativePath,
+            DrivelineRelativePath,
         ], extractedDir =>
             File.AppendAllText(
-                Path.Combine(extractedDir, PostProcessor.DrivelineRelativePath),
+                Path.Combine(extractedDir, DrivelineRelativePath),
                 $"{Environment.NewLine}END")
             );
 


### PR DESCRIPTION
Closes #132 and fixes #103.

- [x] Create mod configuration files on install after extracting config (excluding Bootfiles)
  - [ ] Do not generate AMS2CM comments on
  - [ ] Generate better mod name in `UserData\Mods`
- [ ] Read those files at bootfiles install and stop passing config from mod to bootfiles install
- [ ] Move all bootfiles logic into `Bootfiles` namespace
- [ ] Create mod manifest and skip bootfiles for that mod
  - [ ] Configuration flag to disable it, true by default?
