### PR TITLE
Convert old vehicles mods to new mod format on install

### DIFF
--- a/src/Core/API/Config.cs
+++ b/src/Core/API/Config.cs
@@ -40,4 +40,5 @@ public class ModInstallConfig : ModInstaller.IConfig
     public IEnumerable<string> DirsAtRoot { get; set; } = Array.Empty<string>();
     public IEnumerable<string> ExcludedFromInstall { get; set; } = Array.Empty<string>();
     public IEnumerable<string> ExcludedFromConfig { get; set; } = Array.Empty<string>();
+    public bool GenerateModDetails { get; set; } = true;
 }

--- a/src/Core/Mods/Installation/Installers/ModInstaller.cs
+++ b/src/Core/Mods/Installation/Installers/ModInstaller.cs
@@ -1,5 +1,4 @@
 ﻿using Core.Games;
-using Core.Packages.Installation.Backup;
 using Core.Packages.Installation.Installers;
 using Core.Utils;
 using Microsoft.Extensions.FileSystemGlobbing;
@@ -17,14 +16,21 @@ public class ModInstaller : BaseModInstaller
         {
             get;
         }
+
+        bool GenerateModDetails
+        {
+            get;
+        }
     }
 
     private readonly Matcher filesToConfigureMatcher;
+    private readonly bool generateModDetails;
 
     internal ModInstaller(IInstaller inner, IGame game, ITempDir tempDir, IConfig config) :
         base(inner, game, tempDir, config)
     {
         filesToConfigureMatcher = Matchers.ExcludingPatterns(config.ExcludedFromConfig);
+        generateModDetails = config.GenerateModDetails;
     }
 
     protected override void Install(Action innerInstall)
@@ -65,6 +71,10 @@ public class ModInstaller : BaseModInstaller
         AddToInstalledFiles(PostProcessor.AppendCrdFileEntries(modConfigDirPath, modConfig.CrdFileEntries));
         AddToInstalledFiles(PostProcessor.AppendTrdFileEntries(modConfigDirPath, modConfig.TrdFileEntries));
         AddToInstalledFiles(PostProcessor.AppendDrivelineRecords(modConfigDirPath, modConfig.DrivelineRecords));
+        if (generateModDetails && (modConfig.CrdFileEntries.Any() || modConfig.DrivelineRecords.Any()))
+        {
+            AddToInstalledFiles(PostProcessor.GenerateModDetails(modConfigDirPath, Inner));
+        }
     }
 
     private List<string> CrdFileEntries() =>

--- a/src/Core/Mods/Installation/Installers/PostProcessor.cs
+++ b/src/Core/Mods/Installation/Installers/PostProcessor.cs
@@ -1,4 +1,5 @@
-﻿using Core.Utils;
+﻿using Core.Packages.Installation;
+using Core.Utils;
 
 namespace Core.Mods.Installation.Installers;
 
@@ -108,4 +109,26 @@ internal static class PostProcessor
     }
 
     private static string IdentityProcessor(string block) => block;
+
+    public static RootedPath GenerateModDetails(RootedPath destDirPath, IInstallation installation)
+    {
+        var modName = Path.GetFileName(destDirPath.Full);
+        var filePath = destDirPath.SubPath($"{modName}.xml");
+        var contents = @$"<?xml version=""1.0""?>
+<Reflection>
+    <class name=""BRTTIRefCount"" base=""root class"" />
+    <class name=""BPersistent"" base=""BRTTIRefCount"">
+        <prop name=""Name"" type=""String"" />
+    </class>
+    <class name=""ModDetails"" base=""BPersistent"">
+        <prop name=""DisplayName"" type=""String"" />
+    </class>
+    <data class=""ModDetails"" id=""0x{installation.PackageFsHash:x08}"">
+        <prop name=""Name"" data=""{modName}"" />
+        <prop name=""DisplayName"" data=""{installation.PackageName}"" />
+    </data>
+</Reflection>";
+        File.WriteAllText(filePath.Full, contents);
+        return filePath;
+    }
 }


### PR DESCRIPTION
Closes #132

- Create mod manifest and skip bootfiles for that mod
- Configuration flag to disable it, true by default