### PR TITLE
Mod dependencies

### DIFF
--- a/src/Core/API/IEventHandler.cs
+++ b/src/Core/API/IEventHandler.cs
@@ -2,6 +2,6 @@
 
 namespace Core.API;
 
-public interface IEventHandler : ModPackagesesUpdater.IEventHandler
+public interface IEventHandler : ModPackagesUpdater.IEventHandler
 {
 }

--- a/src/Core/API/Init.cs
+++ b/src/Core/API/Init.cs
@@ -25,14 +25,14 @@ public static class Init
         return new ModManager(game, modRepository, packagesUpdater, statePersistence, safeFileDelete, tempDir);
     }
 
-    internal static ModPackagesesUpdater CreateModPackagesUpdater(
+    internal static ModPackagesUpdater CreateModPackagesUpdater(
         ModInstallConfig installerConfig,
         IGame game,
         ITempDir tempDir)
     {
         var backupStrategy = new SuffixBackupStrategy();
         var backupStrategyProvider = new SkipUpdatedBackupStrategy.Provider(backupStrategy);
-        return new ModPackagesesUpdater(
+        return new ModPackagesUpdater(
             new FileSystemInstallerFactory(), backupStrategyProvider,
             TimeProvider.System, game, tempDir, installerConfig);
     }

--- a/src/Core/API/ModManager.cs
+++ b/src/Core/API/ModManager.cs
@@ -28,7 +28,7 @@ internal class ModManager : IModManager
         this.packagesUpdater = packagesUpdater;
     }
 
-    private static void AddToEnvionmentPath(string additionalPath)
+    private static void AddToEnvironmentPath(string additionalPath)
     {
         const string pathEnvVar = "PATH";
         var env = Environment.GetEnvironmentVariable(pathEnvVar);
@@ -128,9 +128,9 @@ internal class ModManager : IModManager
     public void InstallEnabledMods(IEventHandler eventHandler, CancellationToken cancellationToken = default)
     {
         CheckGameNotRunning();
-        // It shoulnd't be needed, but some systems seem to want to load oo2core
+        // It shouldn't be needed, but some systems seem to want to load oo2core
         // even when Mermaid and Kraken compression are not used in pak files!
-        AddToEnvionmentPath(game.InstallationDirectory);
+        AddToEnvironmentPath(game.InstallationDirectory);
 
         // Clean what left by a previous failed installation
         tempDir.Cleanup();

--- a/src/Core/API/ModManager.cs
+++ b/src/Core/API/ModManager.cs
@@ -47,7 +47,7 @@ internal class ModManager : IModManager
         var availableModPackages = enabledModPackages.Merge(disabledModPackages);
 
         var isModInstalled = DependencyResolver
-            .CollectValues(installedMods, s => s.Dependencies, s => s?.Partial ?? true)
+            .CollectValues(installedMods, s => s.Dependencies ?? Array.Empty<string>(), s => s?.Partial ?? true)
             .SelectValues<string, IReadOnlySet<bool>, bool?>(partials => partials.Any(p => p) ? null : true);
 
         var modsOutOfDate = installedMods.SelectValues((packageName, modInstallationState) =>

--- a/src/Core/API/ModManager.cs
+++ b/src/Core/API/ModManager.cs
@@ -1,6 +1,5 @@
 using Core.Games;
 using Core.IO;
-using Core.Mods;
 using Core.Mods.Installation;
 using Core.Packages.Installation;
 using Core.Packages.Repository;

--- a/src/Core/API/ModManager.cs
+++ b/src/Core/API/ModManager.cs
@@ -16,16 +16,16 @@ internal class ModManager : IModManager
     private readonly ISafeFileDelete safeFileDelete;
     private readonly ITempDir tempDir;
 
-    private readonly ModPackagesesUpdater packagesesUpdater;
+    private readonly ModPackagesUpdater packagesUpdater;
 
-    internal ModManager(IGame game, IPackageRepository packageRepository, ModPackagesesUpdater packagesesUpdater, IStatePersistence statePersistence, ISafeFileDelete safeFileDelete, ITempDir tempDir)
+    internal ModManager(IGame game, IPackageRepository packageRepository, ModPackagesUpdater packagesUpdater, IStatePersistence statePersistence, ISafeFileDelete safeFileDelete, ITempDir tempDir)
     {
         this.game = game;
         this.packageRepository = packageRepository;
         this.statePersistence = statePersistence;
         this.safeFileDelete = safeFileDelete;
         this.tempDir = tempDir;
-        this.packagesesUpdater = packagesesUpdater;
+        this.packagesUpdater = packagesUpdater;
     }
 
     private static void AddToEnvionmentPath(string additionalPath)
@@ -155,7 +155,7 @@ internal class ModManager : IModManager
 
     private void UpdateMods(IEnumerable<Package> packages, IEventHandler eventHandler, CancellationToken cancellationToken)
     {
-        packagesesUpdater.Apply(
+        packagesUpdater.Apply(
             statePersistence.ReadState().Install.Mods,
             packages,
             game.InstallationDirectory,

--- a/src/Core/Mods/Installation/Installers/BaseModInstaller.cs
+++ b/src/Core/Mods/Installation/Installers/BaseModInstaller.cs
@@ -50,6 +50,8 @@ public abstract class BaseModInstaller : IInstaller
 
     public int? PackageFsHash => Inner.PackageFsHash;
 
+    public abstract IReadOnlyCollection<string> PackageDependencies { get; }
+
     public IReadOnlyCollection<RootedPath> InstalledFiles =>
         Inner.InstalledFiles
             .Concat(localInstalledFiles)

--- a/src/Core/Mods/Installation/Installers/BootfilesInstaller.cs
+++ b/src/Core/Mods/Installation/Installers/BootfilesInstaller.cs
@@ -35,6 +35,9 @@ public class BootfilesInstaller : BaseModInstaller
     private static IInstaller PackageOrGenerated(IInstaller? bootfilesPackageInstaller, IGame game, ITempDir tempDir) =>
         bootfilesPackageInstaller ?? new GeneratedBootfilesInstaller(GeneratedBootfilesPackageName, game, tempDir);
 
+    // Bootfiles cannot have dependencies.
+    public override IReadOnlyCollection<string> PackageDependencies => Array.Empty<string>();
+
     protected override void Install(Action innerInstall)
     {
         var modConfigs = CollectModConfigs();

--- a/src/Core/Mods/Installation/Installers/BootfilesInstaller.cs
+++ b/src/Core/Mods/Installation/Installers/BootfilesInstaller.cs
@@ -18,7 +18,7 @@ public class BootfilesInstaller : BaseModInstaller
         void PostProcessingEnd();
     }
 
-    private const string GeneratedBootfilesPackageName = $"{ModPackagesesUpdater.BootfilesPrefix}_generated";
+    private const string GeneratedBootfilesPackageName = $"{ModPackagesUpdater.BootfilesPrefix}_generated";
 
     internal const string VehicleListRelativeDir = "vehicles";
     internal static readonly string TrackListRelativeDir = Path.Combine("tracks", "_data");

--- a/src/Core/Mods/Installation/Installers/ModInstaller.cs
+++ b/src/Core/Mods/Installation/Installers/ModInstaller.cs
@@ -52,9 +52,6 @@ public class ModInstaller : BaseModInstaller
 
     private void WriteModConfigFiles(ConfigEntries modConfig)
     {
-        // TODO remove in later bootfiles refactoring
-        if (ModPackagesesUpdater.IsBootFiles(PackageName))
-            return;
         if (modConfig.None())
             return;
 

--- a/src/Core/Mods/Installation/Installers/ModInstaller.cs
+++ b/src/Core/Mods/Installation/Installers/ModInstaller.cs
@@ -1,4 +1,5 @@
-﻿using Core.Games;
+﻿using System.Collections.Immutable;
+using Core.Games;
 using Core.Packages.Installation.Installers;
 using Core.Utils;
 using Microsoft.Extensions.FileSystemGlobbing;
@@ -26,12 +27,19 @@ public class ModInstaller : BaseModInstaller
     private readonly Matcher filesToConfigureMatcher;
     private readonly bool generateModDetails;
 
-    internal ModInstaller(IInstaller inner, IGame game, ITempDir tempDir, IConfig config) :
+    private IReadOnlyCollection<string> bootfilesDependency = Array.Empty<string>();
+    private readonly string bootfilesPackageName;
+
+    internal ModInstaller(IInstaller inner, string bootfilesPackageName, IGame game, ITempDir tempDir, IConfig config) :
         base(inner, game, tempDir, config)
     {
+        this.bootfilesPackageName = bootfilesPackageName;
         filesToConfigureMatcher = Matchers.ExcludingPatterns(config.ExcludedFromConfig);
         generateModDetails = config.GenerateModDetails;
     }
+
+    public override IReadOnlyCollection<string> PackageDependencies =>
+        Inner.PackageDependencies.Concat(bootfilesDependency).ToImmutableList();
 
     protected override void Install(Action innerInstall)
     {
@@ -68,9 +76,12 @@ public class ModInstaller : BaseModInstaller
         AddToInstalledFiles(PostProcessor.AppendCrdFileEntries(modConfigDirPath, modConfig.CrdFileEntries));
         AddToInstalledFiles(PostProcessor.AppendTrdFileEntries(modConfigDirPath, modConfig.TrdFileEntries));
         AddToInstalledFiles(PostProcessor.AppendDrivelineRecords(modConfigDirPath, modConfig.DrivelineRecords));
-        if (generateModDetails && (modConfig.CrdFileEntries.Any() || modConfig.DrivelineRecords.Any()))
+        if (generateModDetails && !modConfig.TrdFileEntries.Any())
         {
             AddToInstalledFiles(PostProcessor.GenerateModDetails(modConfigDirPath, Inner));
+        } else
+        {
+            bootfilesDependency = new[] { bootfilesPackageName };
         }
     }
 

--- a/src/Core/Mods/Installation/ModPackagesUpdater.cs
+++ b/src/Core/Mods/Installation/ModPackagesUpdater.cs
@@ -51,9 +51,10 @@ public class ModPackagesUpdater : PackagesUpdater<ModPackagesUpdater.IEventHandl
     {
         var (bootfiles, notBootfiles) = installers.Partition(p => IsBootFiles(p.PackageName));
 
+        var bootfilesInstaller = CreateBootfilesInstaller(bootfiles, eventHandler);
         var allInstallers = notBootfiles
-            .Select(i => new ModInstaller(i, game, tempDir, config))
-            .Append(CreateBootfilesInstaller(bootfiles, eventHandler)).ToImmutableArray();
+            .Select(i => new ModInstaller(i, bootfilesInstaller.PackageName, game, tempDir, config))
+            .Append(bootfilesInstaller).ToImmutableArray();
 
         base.Apply(currentState, allInstallers, installDir, afterInstall, eventHandler, cancellationToken);
     }

--- a/src/Core/Mods/Installation/ModPackagesUpdater.cs
+++ b/src/Core/Mods/Installation/ModPackagesUpdater.cs
@@ -8,7 +8,7 @@ using Core.Utils;
 
 namespace Core.Mods.Installation;
 
-public class ModPackagesesUpdater : PackagesUpdater<ModPackagesesUpdater.IEventHandler>
+public class ModPackagesUpdater : PackagesUpdater<ModPackagesUpdater.IEventHandler>
 {
     #region TODO Move to a better place when not called all over the place
 
@@ -19,7 +19,7 @@ public class ModPackagesesUpdater : PackagesUpdater<ModPackagesesUpdater.IEventH
 
     #endregion
 
-    public new interface IEventHandler : PackagesUpdater.IEventHandler, BootfilesInstaller.IEventHandler
+    public interface IEventHandler : PackagesUpdater.IEventHandler, BootfilesInstaller.IEventHandler
     {
     }
 
@@ -27,7 +27,7 @@ public class ModPackagesesUpdater : PackagesUpdater<ModPackagesesUpdater.IEventH
     private readonly ITempDir tempDir;
     private readonly ModInstaller.IConfig config;
 
-    public ModPackagesesUpdater(
+    public ModPackagesUpdater(
         IInstallerFactory installerFactory,
         IBackupStrategyProvider<PackageInstallationState> backupStrategyProvider,
         TimeProvider timeProvider,

--- a/src/Core/Packages/Installation/IInstallation.cs
+++ b/src/Core/Packages/Installation/IInstallation.cs
@@ -6,6 +6,8 @@ public interface IInstallation
 {
     string PackageName { get; }
     int? PackageFsHash { get; }
+    IReadOnlyCollection<string> PackageDependencies { get; }
+
     IReadOnlyCollection<RootedPath> InstalledFiles { get; }
     State Installed { get; }
 

--- a/src/Core/Packages/Installation/IInstallation.cs
+++ b/src/Core/Packages/Installation/IInstallation.cs
@@ -6,9 +6,9 @@ public interface IInstallation
 {
     string PackageName { get; }
     int? PackageFsHash { get; }
-
     IReadOnlyCollection<RootedPath> InstalledFiles { get; }
     State Installed { get; }
+
     enum State
     {
         NotInstalled = 0,

--- a/src/Core/Packages/Installation/Installers/BaseInstaller.cs
+++ b/src/Core/Packages/Installation/Installers/BaseInstaller.cs
@@ -12,6 +12,9 @@ internal abstract class BaseInstaller<TPassthrough> : IInstaller
     public string PackageName { get; }
     public int? PackageFsHash { get; }
 
+    // A package cannot currently specify dependencies.
+    public IReadOnlyCollection<string> PackageDependencies => Array.Empty<string>();
+
     public IInstallation.State Installed { get; private set; }
     public IReadOnlyCollection<RootedPath> InstalledFiles => installedFiles;
 

--- a/src/Core/Packages/Installation/PackageInstallationState.cs
+++ b/src/Core/Packages/Installation/PackageInstallationState.cs
@@ -8,6 +8,7 @@ public record PackageInstallationState(
     // TODO: needed for backward compatibility
     // infer from null hash after the first install
     bool Partial,
-    IReadOnlyCollection<string> Dependencies,
+    // TODO: needed for backward compatibility
+    IReadOnlyCollection<string>? Dependencies,
     IReadOnlyCollection<string> Files
 );

--- a/src/Core/Packages/Installation/PackageInstallationState.cs
+++ b/src/Core/Packages/Installation/PackageInstallationState.cs
@@ -8,8 +8,6 @@ public record PackageInstallationState(
     // TODO: needed for backward compatibility
     // infer from null hash after the first install
     bool Partial,
+    IReadOnlyCollection<string> Dependencies,
     IReadOnlyCollection<string> Files
-)
-{
-    public static PackageInstallationState Empty => new(null, null, false, Array.Empty<string>());
-}
+);

--- a/src/Core/Packages/Installation/PackagesUpdater.cs
+++ b/src/Core/Packages/Installation/PackagesUpdater.cs
@@ -163,12 +163,7 @@ public class PackagesUpdater<TEventHandler>
         TEventHandler eventHandler,
         CancellationToken cancellationToken)
     {
-        var allInstalledFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        var installCallbacks = new ProcessingCallbacks<RootedPath>
-        {
-            Accept = gamePath => !allInstalledFiles.Contains(gamePath.Relative),
-            Before = gamePath => allInstalledFiles.Add(gamePath.Relative)
-        };
+        var allInstalledFiles = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
         // Increase by one in case bootfiles are needed and another one to show that something is happening
         var progress = new PercentOfTotal(installers.Count + 2);
@@ -181,6 +176,24 @@ public class PackagesUpdater<TEventHandler>
             {
                 eventHandler.InstallCurrent(installer.PackageName);
                 var backupStrategy = backupStrategyProvider.BackupStrategy(null);
+                var automaticDependencies = new HashSet<string>();
+                var installCallbacks = new ProcessingCallbacks<RootedPath>
+                {
+                    Accept = gamePath =>
+                    {
+                        var overridingPackageName = allInstalledFiles.GetValueOrDefault(gamePath.Relative);
+                        if (overridingPackageName is null)
+                        {
+                            return true;
+                        }
+                        if (overridingPackageName != installer.PackageName)
+                        {
+                            automaticDependencies.Add(overridingPackageName);
+                        }
+                        return false;
+                    },
+                    Before = gamePath => allInstalledFiles.Add(gamePath.Relative, installer.PackageName)
+                };
                 try
                 {
                     installer.Install(InstallTo(destinationDir), backupStrategy, installCallbacks);
@@ -191,6 +204,7 @@ public class PackagesUpdater<TEventHandler>
                         .Where(rp => rp.Root == destinationDir)
                         .Select(rp => rp.Relative)
                         .ToImmutableList();
+                    automaticDependencies.UnionWith(installer.PackageDependencies);
                     afterInstall(installer.PackageName,
                         packageInstalledFiles.Count == 0
                             ? null
@@ -198,7 +212,7 @@ public class PackagesUpdater<TEventHandler>
                                 Time: timeProvider.GetUtcNow().DateTime,
                                 FsHash: installer.PackageFsHash,
                                 Partial: installer.Installed == IInstallation.State.PartiallyInstalled,
-                                Dependencies: installer.PackageDependencies,
+                                Dependencies: automaticDependencies,
                                 Files: packageInstalledFiles
                         ));
                 }

--- a/src/Core/Packages/Installation/PackagesUpdater.cs
+++ b/src/Core/Packages/Installation/PackagesUpdater.cs
@@ -198,6 +198,7 @@ public class PackagesUpdater<TEventHandler>
                                 Time: timeProvider.GetUtcNow().DateTime,
                                 FsHash: installer.PackageFsHash,
                                 Partial: installer.Installed == IInstallation.State.PartiallyInstalled,
+                                Dependencies: installer.PackageDependencies,
                                 Files: packageInstalledFiles
                         ));
                 }

--- a/src/Core/State/JsonFileStatePersistence.cs
+++ b/src/Core/State/JsonFileStatePersistence.cs
@@ -52,7 +52,10 @@ internal class JsonFileStatePersistence : IStatePersistence
                     Time: installTime,
                     Mods: oldState.AsEnumerable().ToDictionary(
                         kv => kv.Key,
-                        kv => new PackageInstallationState(Time: installTime, FsHash: null, Partial: false, Files: kv.Value)
+                        kv => new PackageInstallationState(
+                            Time: installTime, FsHash: null, Partial: false,
+                            Dependencies: Array.Empty<string>(),
+                            Files: kv.Value)
                     )
                 )
             );

--- a/src/Core/Utils/DependencyResolver.cs
+++ b/src/Core/Utils/DependencyResolver.cs
@@ -1,0 +1,40 @@
+﻿using System.Collections.Immutable;
+
+namespace Core.Utils;
+
+public static class DependencyResolver
+{
+    /// <summary>
+    /// Resolves individual dependencies into transitive ones.
+    /// </summary>
+    /// <param name="individualDependencies">Individual dependencies</param>
+    /// <returns>Transitive dependencies</returns>
+    public static IDictionary<string, IReadOnlySet<string>> Transitive(
+        IDictionary<string, IReadOnlyCollection<string>> individualDependencies)
+    {
+        var transitiveDependencies = new Dictionary<string, IReadOnlySet<string>>();
+
+        IEnumerable<string> TransitiveDependencies(string item)
+        {
+            if (transitiveDependencies.TryGetValue(item, out var td))
+            {
+                return td;
+            }
+
+            if (!individualDependencies.TryGetValue(item, out var id))
+            {
+                return ImmutableHashSet<string>.Empty;
+            }
+
+            td = id.Concat(id.SelectMany(TransitiveDependencies)).ToHashSet();
+            transitiveDependencies.Add(item, td);
+            return td;
+        }
+
+        foreach (var item in individualDependencies.Keys)
+        {
+            TransitiveDependencies(item);
+        }
+        return transitiveDependencies;
+    }
+}

--- a/tests/Core.Tests/API/ModManagerIntegrationTest.cs
+++ b/tests/Core.Tests/API/ModManagerIntegrationTest.cs
@@ -352,11 +352,12 @@ public class ModManagerIntegrationTest : AbstractFilesystemTest
     }
 
     [Fact]
-    public void Install_GivesPriotiryToFilesLaterInTheModList()
+    public void Install_GivesPriorityToFilesLaterInTheModList()
     {
         modRepositoryMock.Setup(_ => _.ListEnabled()).Returns([
             CreateModArchive(100, [
-                Path.Combine(DirAtRoot, "A")
+                Path.Combine(DirAtRoot, "A"),
+                Path.Combine(DirAtRoot, "B")
             ]),
             CreateModArchive(200, [
                 Path.Combine("X", DirAtRoot, "a")
@@ -368,6 +369,11 @@ public class ModManagerIntegrationTest : AbstractFilesystemTest
         File.ReadAllText(GamePath(DirAtRoot, "A").Full).Should().Be("200");
         persistedState.Should().HaveInstalled(new Dictionary<string, PackageInstallationState>
         {
+            ["Package100"] = new(Time: DateTime.UtcNow, FsHash: 100, Partial: false,
+                Dependencies: ["Package200"],
+                Files: [
+                    Path.Combine(DirAtRoot, "B")
+                ]),
             ["Package200"] = new(Time: DateTime.UtcNow, FsHash: 200, Partial: false,
                 Dependencies: [],
                 Files: [

--- a/tests/Core.Tests/API/ModManagerIntegrationTest.cs
+++ b/tests/Core.Tests/API/ModManagerIntegrationTest.cs
@@ -598,7 +598,7 @@ public class ModManagerIntegrationTest : AbstractFilesystemTest
         CreateModPackage("Package", fsHash, relativePaths, callback);
 
     private Package CreateCustomBootfiles(int fsHash) =>
-        CreateModPackage(ModPackagesesUpdater.BootfilesPrefix, fsHash, [
+        CreateModPackage(ModPackagesUpdater.BootfilesPrefix, fsHash, [
                 Path.Combine(DirAtRoot, "OrTheyWontBeInstalled"),
             VehicleListRelativePath,
             TrackListRelativePath,

--- a/tests/Core.Tests/API/ModManagerIntegrationTest.cs
+++ b/tests/Core.Tests/API/ModManagerIntegrationTest.cs
@@ -92,12 +92,16 @@ public class ModManagerIntegrationTest : AbstractFilesystemTest
                 Mods: new Dictionary<string, PackageInstallationState>
                 {
                     ["A"] = new(
-                        Time: null, FsHash: null, Partial: false, Files: [
+                        Time: null, FsHash: null, Partial: false,
+                        Dependencies: [],
+                        Files: [
                             Path.Combine("X", "ModAFile"),
                             Path.Combine("Y", "ModAFile")
                         ]),
                     ["B"] = new(
-                        Time: null, FsHash: null, Partial: false, Files: [
+                        Time: null, FsHash: null, Partial: false,
+                        Dependencies: [],
+                        Files: [
                             Path.Combine("X", "ModBFile")
                         ])
                 }
@@ -124,7 +128,9 @@ public class ModManagerIntegrationTest : AbstractFilesystemTest
                 Mods: new Dictionary<string, PackageInstallationState>
                 {
                     [""] = new(
-                        Time: installationDateTime.ToUniversalTime(), FsHash: null, Partial: false, Files: [
+                        Time: installationDateTime.ToUniversalTime(), FsHash: null, Partial: false,
+                        Dependencies: [],
+                        Files: [
                             "ModFile",
                             "RecreatedFile",
                             "AlreadyDeletedFile"
@@ -153,16 +159,22 @@ public class ModManagerIntegrationTest : AbstractFilesystemTest
                 Mods: new Dictionary<string, PackageInstallationState>
                 {
                     ["A"] = new(
-                        Time: installationDateTime.ToUniversalTime(), FsHash: null, Partial: false, Files: [
+                        Time: installationDateTime.ToUniversalTime(), FsHash: null, Partial: false,
+                        Dependencies: [],
+                        Files: [
                             "ModAFile"
                         ]),
                     ["B"] = new(
-                        Time: installationDateTime.ToUniversalTime(), FsHash: null, Partial: false, Files: [
+                        Time: installationDateTime.ToUniversalTime(), FsHash: null, Partial: false,
+                        Dependencies: [],
+                        Files: [
                             "ModBFile1",
                             "ModBFile2"
                         ]),
                     ["C"] = new(
-                        Time: installationDateTime.ToUniversalTime(), FsHash: null, Partial: false, Files: [
+                        Time: installationDateTime.ToUniversalTime(), FsHash: null, Partial: false,
+                        Dependencies: [],
+                        Files: [
                             "ModCFile"
                         ])
                 }
@@ -182,11 +194,15 @@ public class ModManagerIntegrationTest : AbstractFilesystemTest
                 Mods: new Dictionary<string, PackageInstallationState>
                 {
                     ["B"] = new(
-                        Time: installationDateTime.ToUniversalTime(), FsHash: null, Partial: true, Files: [
+                        Time: installationDateTime.ToUniversalTime(), FsHash: null, Partial: true,
+                        Dependencies: [],
+                        Files: [
                             "ModBFile2"
                         ]),
                     ["C"] = new(
-                        Time: installationDateTime.ToUniversalTime(), FsHash: null, Partial: false, Files: [
+                        Time: installationDateTime.ToUniversalTime(), FsHash: null, Partial: false,
+                        Dependencies: [],
+                        Files: [
                             "ModCFile"
                         ])
                 }
@@ -203,7 +219,9 @@ public class ModManagerIntegrationTest : AbstractFilesystemTest
                 Mods: new Dictionary<string, PackageInstallationState>
                 {
                     [""] = new(
-                        Time: null, FsHash: null, Partial: false, Files: [
+                        Time: null, FsHash: null, Partial: false,
+                        Dependencies: [],
+                        Files: [
                             "ModFile"
                         ])
                 }
@@ -229,7 +247,9 @@ public class ModManagerIntegrationTest : AbstractFilesystemTest
                 Mods: new Dictionary<string, PackageInstallationState>
                 {
                     [""] = new(
-                        Time: installationDateTime.ToUniversalTime(), FsHash: null, Partial: false, Files: [
+                        Time: installationDateTime.ToUniversalTime(), FsHash: null, Partial: false,
+                        Dependencies: [],
+                        Files: [
                             "ModFile"
                         ])
                 }
@@ -280,7 +300,9 @@ public class ModManagerIntegrationTest : AbstractFilesystemTest
         persistedState.Should().HaveInstalled(new Dictionary<string, PackageInstallationState>
         {
             ["Package100"] = new(
-                    Time: DateTime.UtcNow, FsHash: 100, Partial: false, Files: [
+                    Time: DateTime.UtcNow, FsHash: 100, Partial: false,
+                    Dependencies: [],
+                    Files: [
                         Path.Combine(DirAtRoot, "A"),
                         Path.Combine(DirAtRoot, "B"),
                         "C"
@@ -305,7 +327,9 @@ public class ModManagerIntegrationTest : AbstractFilesystemTest
         persistedState.Should().HaveInstalled(new Dictionary<string, PackageInstallationState>
         {
             ["Package100"] = new(
-                    Time: DateTime.UtcNow, FsHash: 100, Partial: false, Files: [
+                    Time: DateTime.UtcNow, FsHash: 100, Partial: false,
+                    Dependencies: [],
+                    Files: [
                         Path.Combine(DirAtRoot, "B")
                     ]),
         });
@@ -344,7 +368,9 @@ public class ModManagerIntegrationTest : AbstractFilesystemTest
         File.ReadAllText(GamePath(DirAtRoot, "A").Full).Should().Be("200");
         persistedState.Should().HaveInstalled(new Dictionary<string, PackageInstallationState>
         {
-            ["Package200"] = new(Time: DateTime.UtcNow, FsHash: 200, Partial: false, Files: [
+            ["Package200"] = new(Time: DateTime.UtcNow, FsHash: 200, Partial: false,
+                Dependencies: [],
+                Files: [
                     Path.Combine(DirAtRoot, "a")
                 ]),
         });
@@ -364,7 +390,9 @@ public class ModManagerIntegrationTest : AbstractFilesystemTest
 
         persistedState.Should().HaveInstalled(new Dictionary<string, PackageInstallationState>
         {
-            ["Package100"] = new(Time: DateTime.UtcNow, FsHash: 100, Partial: false, Files: [
+            ["Package100"] = new(Time: DateTime.UtcNow, FsHash: 100, Partial: false,
+                Dependencies: [],
+                Files: [
                     Path.Combine(DirAtRoot, "A")
                 ]),
         });
@@ -401,12 +429,16 @@ public class ModManagerIntegrationTest : AbstractFilesystemTest
                 Mods: new Dictionary<string, PackageInstallationState>
                 {
                     ["Package200"] = new(
-                        Time: DateTime.UtcNow, FsHash: 200, Partial: true, Files: [
+                        Time: DateTime.UtcNow, FsHash: 200, Partial: true,
+                        Dependencies: [],
+                        Files: [
                             Path.Combine(DirAtRoot, "B1"),
                             Path.Combine(DirAtRoot, "B2") // We don't know when it failed
                         ]),
                     ["Package300"] = new(
-                        Time: DateTime.UtcNow, FsHash: 300, Partial: false, Files: [
+                        Time: DateTime.UtcNow, FsHash: 300, Partial: false,
+                        Dependencies: [],
+                        Files: [
                             Path.Combine(DirAtRoot, "C")
                         ]),
                 }
@@ -449,7 +481,25 @@ public class ModManagerIntegrationTest : AbstractFilesystemTest
     }
 
     [Fact]
-    public void Install_OldVehiclesDoNotRequireBootfiles()
+    public void Install_GameSupportedModsNeverRequireBootfiles()
+    {
+        modRepositoryMock.Setup(_ => _.ListEnabled()).Returns([
+            CreateModArchive(100, [
+                Path.Combine(DirAtRoot, "Vehicle.crd"),
+                Path.Combine(DirAtRoot, "Track.trd"), // Tracks do not currently work in game
+                Path.Combine(PostProcessor.GameSupportedModDirectory, "Anything")
+            ]),
+            CreateCustomBootfiles(900),
+        ]);
+
+        modManager.InstallEnabledMods(eventHandlerMock.Object);
+
+        persistedState.Should().HaveInstalled(["Package100"]);
+        persistedState.For("Package100").Dependencies.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Install_OldVehicleModsDoNotRequireBootfiles()
     {
         var drivelineRecord = $"RECORD foo";
         modRepositoryMock.Setup(_ => _.ListEnabled()).Returns([
@@ -464,6 +514,8 @@ public class ModManagerIntegrationTest : AbstractFilesystemTest
         modManager.InstallEnabledMods(eventHandlerMock.Object);
 
         persistedState.Should().HaveInstalled(["Package100"]);
+        persistedState.For("Package100").Dependencies.Should().BeEmpty();
+
         var generatedConfigDir = $"Package100_{100:x}";
         File.ReadAllText(GamePath(PostProcessor.GameSupportedModDirectory, generatedConfigDir,
             PostProcessor.VehicleListFileName).Full).Should().Contain("Vehicle.crd");
@@ -474,32 +526,22 @@ public class ModManagerIntegrationTest : AbstractFilesystemTest
     }
 
     [Fact]
-    public void Install_NewVehiclesDoNotRequireBootfiles()
+    public void Install_OldTrackModsAlwaysRequireBootfiles()
     {
         modRepositoryMock.Setup(_ => _.ListEnabled()).Returns([
             CreateModArchive(100, [
-                Path.Combine(DirAtRoot, "Vehicle.crd"),
-                Path.Combine(PostProcessor.GameSupportedModDirectory, "Anything")
+                Path.Combine(DirAtRoot, "Track.trd"),
+                // Vehicles are not upgraded to game-supported mods if tracks are present
+                Path.Combine(DirAtRoot, "Vehicle.crd")
             ]),
             CreateCustomBootfiles(900),
         ]);
 
         modManager.InstallEnabledMods(eventHandlerMock.Object);
 
-        persistedState.Should().HaveInstalled(["Package100"]);
-    }
-
-    [Fact]
-    public void Install_AllTracksRequireBootfiles()
-    {
-        modRepositoryMock.Setup(_ => _.ListEnabled()).Returns([
-            CreateModArchive(100, [Path.Combine(DirAtRoot, "Track.trd")]),
-            CreateCustomBootfiles(900),
-        ]);
-
-        modManager.InstallEnabledMods(eventHandlerMock.Object);
-
         persistedState.Should().HaveInstalled(["Package100", "__bootfiles900"]);
+        persistedState.For("Package100").Dependencies.Should().Contain("__bootfiles900");
+
         var generatedConfigDir = $"Package100_{100:x}";
         File.ReadAllText(GamePath(PostProcessor.GameSupportedModDirectory, generatedConfigDir,
             PostProcessor.TrackListFileName).Full).Should().Contain("Track.trd");
@@ -595,7 +637,7 @@ public class ModManagerIntegrationTest : AbstractFilesystemTest
                 Time: ValueNotUsed,
                 Mods: new Dictionary<string, PackageInstallationState>
                 {
-                    ["INIT"] = new(Time: null, FsHash: null, Partial: false, Files: []),
+                    ["INIT"] = new(Time: null, FsHash: null, Partial: false, Dependencies: [], Files: []),
                 }
             ));
 
@@ -609,6 +651,13 @@ public class ModManagerIntegrationTest : AbstractFilesystemTest
         public void WriteState(SavedState state) => savedState = state;
 
         internal InMemoryStatePersistenceAssertions Should() => new(savedState);
+
+        internal PackageInstallationState For(string packageName)
+        {
+            var state = savedState?.Install.Mods[packageName];
+            state.Should().NotBeNull();
+            return state!;
+        }
     }
 
     private class InMemoryStatePersistenceAssertions

--- a/tests/Core.Tests/Packages/Installation/PackagesUpdaterIntegrationTest.cs
+++ b/tests/Core.Tests/Packages/Installation/PackagesUpdaterIntegrationTest.cs
@@ -57,6 +57,7 @@ public class PackagesUpdaterIntegrationTest : AbstractFilesystemTest
                         Time: null,
                         FsHash: 42,
                         Partial: false,
+                        Dependencies: [],
                         Files: ["AF"])
             },
             []
@@ -88,6 +89,7 @@ public class PackagesUpdaterIntegrationTest : AbstractFilesystemTest
                         Time: null,
                         FsHash: 42,
                         Partial: false,
+                        Dependencies: [],
                         Files: ["AF1", "Fail", "AF2"])
             },
             []
@@ -110,7 +112,7 @@ public class PackagesUpdaterIntegrationTest : AbstractFilesystemTest
 
         recordedState.Should().BeEquivalentTo(new Dictionary<string, PackageInstallationState>
         {
-            ["A"] = new(fakeUtcInstallationDate, 42, false, ["AF"])
+            ["A"] = new(fakeUtcInstallationDate, 42, false, [], ["AF"])
         });
 
         backupStrategyMock.Verify(_ => _.PerformBackup(TestPath("AF")));
@@ -151,7 +153,7 @@ public class PackagesUpdaterIntegrationTest : AbstractFilesystemTest
         Apply(
             new Dictionary<string, PackageInstallationState>
             {
-                ["A"] = new(Time: null, FsHash: 1, Partial: false, Files: [
+                ["A"] = new(Time: null, FsHash: 1, Partial: false, Dependencies: [], Files: [
                     "AF",
                     "AF1",
                 ])
@@ -166,7 +168,7 @@ public class PackagesUpdaterIntegrationTest : AbstractFilesystemTest
 
         recordedState.Should().BeEquivalentTo(new Dictionary<string, PackageInstallationState>
         {
-            ["A"] = new(fakeUtcInstallationDate, 2, false, ["AF", "AF2"])
+            ["A"] = new(fakeUtcInstallationDate, 2, false, [], ["AF", "AF2"])
         });
     }
 

--- a/tests/Core.Tests/Utils/DependencyResolverTest.cs
+++ b/tests/Core.Tests/Utils/DependencyResolverTest.cs
@@ -6,35 +6,38 @@ namespace Core.Tests.Utils;
 [UnitTest]
 public class DependencyResolverTest
 {
+    private record Item(string Key, string[] Dependencies, string[] Values);
+
+    private IDictionary<string, IReadOnlySet<string>> CollectsValues(IReadOnlyCollection<Item> items) =>
+        DependencyResolver.CollectValues(items, i => i.Key, i => i.Dependencies, i => i.Values);
+
     [Fact]
     public void Transitive_IgnoresMissingDependencies()
     {
-        DependencyResolver
-            .Transitive(new Dictionary<string, IReadOnlyCollection<string>>
-            {
-                ["A"] = new HashSet<string>(["A1"])
-            }).Should().BeEquivalentTo(new Dictionary<string, IReadOnlySet<string>>
-            {
-                ["A"] = new HashSet<string>(["A1"])
-            });
+        CollectsValues([
+            new Item("A", ["B"], ["A1"])
+        ]).Should().BeEquivalentTo(new Dictionary<string, IReadOnlySet<string>>
+        {
+            ["A"] = new HashSet<string>(["A1"])
+        });
     }
 
     [Fact]
     public void Transitive_FollowsDependencyTree()
     {
-        DependencyResolver
-            .Transitive(new Dictionary<string, IReadOnlyCollection<string>>
-            {
-                ["A"] = new HashSet<string>(["B"]),
-                ["B"] = new HashSet<string>(["C", "D"]),
-                ["C"] = new HashSet<string>(["E"]),
-                ["D"] = new HashSet<string>(["E"])
-            }).Should().BeEquivalentTo(new Dictionary<string, IReadOnlySet<string>>
-            {
-                ["A"] = new HashSet<string>(["B", "C", "D", "E"]),
-                ["B"] = new HashSet<string>(["C", "D", "E"]),
-                ["C"] = new HashSet<string>(["E"]),
-                ["D"] = new HashSet<string>(["E"])
-            });
+        CollectsValues([
+            new Item("A", ["B"], ["AV"]),
+            new Item("B", ["C", "D"], ["BV"]),
+            new Item("C", ["E"], []),
+            new Item("D", ["E"], ["DV"]),
+            new Item("E", [], ["EV"])
+        ]).Should().BeEquivalentTo(new Dictionary<string, IReadOnlySet<string>>
+        {
+            ["A"] = new HashSet<string>(["AV", "BV", "DV", "EV"]),
+            ["B"] = new HashSet<string>(["BV", "DV", "EV"]),
+            ["C"] = new HashSet<string>(["EV"]),
+            ["D"] = new HashSet<string>(["DV", "EV"]),
+            ["E"] = new HashSet<string>(["EV"])
+        });
     }
 }

--- a/tests/Core.Tests/Utils/DependencyResolverTest.cs
+++ b/tests/Core.Tests/Utils/DependencyResolverTest.cs
@@ -1,0 +1,40 @@
+﻿using Core.Utils;
+using FluentAssertions;
+
+namespace Core.Tests.Utils;
+
+[UnitTest]
+public class DependencyResolverTest
+{
+    [Fact]
+    public void Transitive_IgnoresMissingDependencies()
+    {
+        DependencyResolver
+            .Transitive(new Dictionary<string, IReadOnlyCollection<string>>
+            {
+                ["A"] = new HashSet<string>(["A1"])
+            }).Should().BeEquivalentTo(new Dictionary<string, IReadOnlySet<string>>
+            {
+                ["A"] = new HashSet<string>(["A1"])
+            });
+    }
+
+    [Fact]
+    public void Transitive_FollowsDependencyTree()
+    {
+        DependencyResolver
+            .Transitive(new Dictionary<string, IReadOnlyCollection<string>>
+            {
+                ["A"] = new HashSet<string>(["B"]),
+                ["B"] = new HashSet<string>(["C", "D"]),
+                ["C"] = new HashSet<string>(["E"]),
+                ["D"] = new HashSet<string>(["E"])
+            }).Should().BeEquivalentTo(new Dictionary<string, IReadOnlySet<string>>
+            {
+                ["A"] = new HashSet<string>(["B", "C", "D", "E"]),
+                ["B"] = new HashSet<string>(["C", "D", "E"]),
+                ["C"] = new HashSet<string>(["E"]),
+                ["D"] = new HashSet<string>(["E"])
+            });
+    }
+}


### PR DESCRIPTION
Closes #103.

- [x] Introduces mod dependencies
- [x] Adds automatic bootfiles dependency for mods that require them
- [x] Adds automatic dependency to mods that shadow package files
- [x] Works out partial installation from transitive dependencies in `FetchState`

Also...
- [x] Fixes typos in `ModPackagesUpdater` class name (44b062af08cd1d64346ba7c65b89ae55a1dfc0ff), `ModManagerIntegrationTest` case name (f2fafcd57a0ec9cd7ee3b9fd8ec1b31dc05c86d5) and `AddToEnvironmentPath` method (d2ce3f8d92bb42c510c72c37b7afd733ee8a5a1a)
- [x] Fixes previously unknown bug of partial installation of bootfiles not being propagated