### PR TITLE
Fix generated bootfiles name

### DIFF
--- a/src/Core/API/ModManager.cs
+++ b/src/Core/API/ModManager.cs
@@ -47,7 +47,7 @@ internal class ModManager : IModManager
         var disabledModPackages = packageRepository.ListDisabled().ToDictionary(_ => _.Name);
         var availableModPackages = enabledModPackages.Merge(disabledModPackages);
 
-        var bootfilesFailed = installedMods.Where(kv => ModUtils.IsBootFiles(kv.Key) && (kv.Value?.Partial ?? false)).Any();
+        var bootfilesFailed = installedMods.Where(kv => ModPackagesesUpdater.IsBootFiles(kv.Key) && (kv.Value?.Partial ?? false)).Any();
         var isModInstalled = installedMods.SelectValues<string, PackageInstallationState, bool?>(modInstallationState =>
             modInstallationState is null ? false : ((modInstallationState.Partial || bootfilesFailed) ? null : true)
         );
@@ -58,7 +58,7 @@ internal class ModManager : IModManager
         });
 
         var allPackageNames = installedMods.Keys
-            .Where(_ => !ModUtils.IsBootFiles(_))
+            .Where(_ => !ModPackagesesUpdater.IsBootFiles(_))
             .Concat(enabledModPackages.Keys)
             .Concat(disabledModPackages.Keys)
             .Distinct();

--- a/src/Core/Mods/Installation/Installers/BootfilesInstaller.cs
+++ b/src/Core/Mods/Installation/Installers/BootfilesInstaller.cs
@@ -18,7 +18,7 @@ public class BootfilesInstaller : BaseModInstaller
         void PostProcessingEnd();
     }
 
-    private const string GeneratedBootfilesPackageName = "__generated_bootfiles";
+    private const string GeneratedBootfilesPackageName = $"{ModPackagesesUpdater.BootfilesPrefix}_generated";
 
     internal const string VehicleListRelativeDir = "vehicles";
     internal static readonly string TrackListRelativeDir = Path.Combine("tracks", "_data");

--- a/src/Core/Mods/Installation/Installers/ModInstaller.cs
+++ b/src/Core/Mods/Installation/Installers/ModInstaller.cs
@@ -53,7 +53,7 @@ public class ModInstaller : BaseModInstaller
     private void WriteModConfigFiles(ConfigEntries modConfig)
     {
         // TODO remove in later bootfiles refactoring
-        if (ModUtils.IsBootFiles(PackageName))
+        if (ModPackagesesUpdater.IsBootFiles(PackageName))
             return;
         if (modConfig.None())
             return;

--- a/src/Core/Mods/Installation/ModPackagesesUpdater.cs
+++ b/src/Core/Mods/Installation/ModPackagesesUpdater.cs
@@ -12,7 +12,7 @@ public class ModPackagesesUpdater : PackagesUpdater<ModPackagesesUpdater.IEventH
 {
     #region TODO Move to a better place when not called all over the place
 
-    public const string BootfilesPrefix = "__bootfiles";
+    internal const string BootfilesPrefix = "__bootfiles";
 
     internal static bool IsBootFiles(string packageName) =>
         packageName.StartsWith(BootfilesPrefix);

--- a/src/Core/Mods/ModUtils.cs
+++ b/src/Core/Mods/ModUtils.cs
@@ -1,9 +1,0 @@
-﻿namespace Core.Mods;
-
-internal class ModUtils
-{
-    internal const string BootfilesPrefix = "__bootfiles";
-
-    internal static bool IsBootFiles(string packageName) =>
-        packageName.StartsWith(BootfilesPrefix);
-}

--- a/tests/Core.Tests/API/ModManagerIntegrationTest.cs
+++ b/tests/Core.Tests/API/ModManagerIntegrationTest.cs
@@ -2,7 +2,7 @@ using System.IO.Compression;
 using Core.API;
 using Core.Games;
 using Core.IO;
-using Core.Mods;
+using Core.Mods.Installation;
 using Core.Mods.Installation.Installers;
 using Core.Packages.Installation;
 using Core.Packages.Installation.Installers;
@@ -550,7 +550,7 @@ public class ModManagerIntegrationTest : AbstractFilesystemTest
         CreateModPackage("Package", fsHash, relativePaths, callback);
 
     private Package CreateCustomBootfiles(int fsHash) =>
-        CreateModPackage(ModUtils.BootfilesPrefix, fsHash, [
+        CreateModPackage(ModPackagesesUpdater.BootfilesPrefix, fsHash, [
                 Path.Combine(DirAtRoot, "OrTheyWontBeInstalled"),
             VehicleListRelativePath,
             TrackListRelativePath,


### PR DESCRIPTION
Closes #142.

- Renames generated bootfiles package to start with the bootfiles prefix
- Removed `ModUtils` since duplicated functionality was moved to `ModPackagesesUpdater` in a previous refactoring